### PR TITLE
Update rubocop to 0.52

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ DEPENDENCIES
   quiet_assets (~> 1.1)
   rspec-html-matchers
   rspec-rails (~> 3.4)
-  rubocop (~> 0.47)
+  rubocop (~> 0.52)
   sass-rails (>= 3.2)
   shoulda-matchers (~> 3.1)
   simplecov (~> 0.11)

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -61,6 +61,6 @@ Gem::Specification.new do |s|
   # Mutes assets pipeline log messages
   s.add_development_dependency "quiet_assets", "~> 1.1"
   # Used to ensure the code base matches our agreed styles and conventions
-  s.add_development_dependency "rubocop", "~> 0.47"
+  s.add_development_dependency "rubocop", "~> 0.52"
   s.add_development_dependency "sass-rails", ">= 3.2"
 end


### PR DESCRIPTION
Update rubocop to resolve a vulnerability warning from GitHub (CVE-2017-8418).