### PR TITLE
Update I18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jquery-rails (4.3.1)
@@ -414,4 +414,4 @@ DEPENDENCIES
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.16.0
+   1.17.3


### PR DESCRIPTION
When we were setting up the vagrant box for FRAE, we noticed the `bundle install` was breaking. Updating the dependency solves the problem.