### PR TITLE
Update privacy policy date to release date

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -76,6 +76,6 @@
     You have the right to <a href="https://ico.org.uk/make-a-complaint">lodge a complaint with the ICO</a> at any time.
   </p>
   <div class="app-c-published-dates">
-    This notice was last updated on 31 May 2019.
+    This notice was last updated on 10 July 2019.
   </div>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-293

As part of the new privacy policy we display the date it was last updated. The date though should represent when the change was visible to users, not when we made the change in the code.

So this change updates the date to match our currently intended release date.