### PR TITLE
Fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=96b5a7037c20be6bd42f3fdff57e81d68e9074dfd81d079413cb84a8342ba10e
+    - ADDRESS_FACADE_CLIENT_ID=0
+    - ADDRESS_FACADE_KEY=client1
+    - ADDRESS_FACADE_PORT=9002
+    - ADDRESS_FACADE_SERVER=localhost
+    - DEVISE_MAILER_SENDER="John Smith <js@example.com>"
+    - EMAIL_HOST=localhost
+    - EMAIL_PORT=2500
+    - SECRET_KEY_BASE=00c33aa9929a0b2fdf6388368469a796fb3d812bee94349d5d9f3a81ecaf35e9195b7ad98bc3a42f27681dd2e6a9b56c589180842ef15630a775f68ccbc2dfc2
 
 language: ruby
 rvm: 2.3.1

--- a/spec/cassettes/forms_address_form_no_street_from_dropdown.yml
+++ b/spec/cassettes/forms_address_form_no_street_from_dropdown.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://addressfacade.cloudapp.net/address-service/v1/addresses/10010175140?client-id=example%20team1&key=client1
+    uri: http://localhost:9002/address-service/v1/addresses/10010175140?client-id=0&key=client1
     body:
       encoding: US-ASCII
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc2 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
       Host:
-      - addressfacade.cloudapp.net
+      - localhost:9002
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 25 May 2016 10:59:04 GMT
+      - Thu, 08 Aug 2019 09:06:24 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -42,6 +42,6 @@ http_interactions:
         osUH+2RtAwhby0SeynwjGtDRaDzsUoRpY9DrDxlroLB4fWU4yCrsA8jdMRB/
         J3J41eTGrgo6LnqUDnBlq12sWrkNaxdSONfH3heStu8K6zdL8VIKNnrR5PAK
         9i6F1Y6T39ffPxNg3hFjAgAA
-    http_version: 
-  recorded_at: Wed, 25 May 2016 11:57:39 GMT
-recorded_with: VCR 3.0.1
+    http_version:
+  recorded_at: Thu, 08 Aug 2019 09:06:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/forms_address_form_valid_uprn_from_dropdown.yml
+++ b/spec/cassettes/forms_address_form_valid_uprn_from_dropdown.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://addressfacade.cloudapp.net/address-service/v1/addresses/340116?client-id=example%20team1&key=client1
+    uri: http://localhost:9002/address-service/v1/addresses/340116?client-id=0&key=client1
     body:
       encoding: US-ASCII
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc2 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
       Host:
-      - addressfacade.cloudapp.net
+      - localhost:9002
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 25 May 2016 10:58:53 GMT
+      - Thu, 08 Aug 2019 09:06:24 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -42,6 +42,6 @@ http_interactions:
         ofvM9C8Q+1IzKgXsSaG8lDFhw5m8Bwne2gHTPQ/Fv6F+o5rNz6fZPMlmqMNI
         vpgusvMkW6BmGl9BKAq8c3sHfPdhj8+KNVxx8MunaZ6l0yz7iiNP0vhubI+4
         cSDgqfzIf9KS+kVg+GHIn7ac9pYNHNrB3gRYbyg5Ph7/AOpo7blrAgAA
-    http_version: 
-  recorded_at: Wed, 25 May 2016 11:57:28 GMT
-recorded_with: VCR 3.0.1
+    http_version:
+  recorded_at: Thu, 08 Aug 2019 09:06:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/limited_company_postcode_address_service_400_test.yml
+++ b/spec/cassettes/limited_company_postcode_address_service_400_test.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://addressfacade.cloudapp.net/address-service/v1/addresses/postcode?client-id=example%20team1&key=client1&postcode=HR4G%200LE
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=HR4G%200LE
     body:
       encoding: US-ASCII
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc2 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
       Host:
-      - addressfacade.cloudapp.net
+      - localhost:9002
   response:
     status:
       code: 400
       message: Bad Request
     headers:
       Date:
-      - Fri, 03 Jun 2016 13:55:19 GMT
+      - Thu, 08 Aug 2019 09:06:20 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -33,5 +33,5 @@ http_interactions:
         postcode must contain a minimum of the sector plus 1 digit of the district
         e.g. SO1. Requested postcode was HR4G0LE"}}}'
     http_version:
-  recorded_at: Fri, 03 Jun 2016 13:54:33 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Thu, 08 Aug 2019 09:06:20 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
When running the tests recently spotted that any that relied on the address lookup were failing. A review of the cassettes highlighted that they have not been rerecorded since May 2016, and it looked like it was something in the response the tests were getting that was causing the error.

So this makes 2 changes

- it re-records the responses to bring them up to date
- it deletes the responses that were hitting our external Azure instance of ABF

The Azure instances were used by the project till VCR was added. As the cassettes are locked and the requests are based on whatever is set in the ENV VARS, there seemed no point in maintaining 2.

Finally as this would mean updating the env vars in Travis, we took the opportunity to add them to `.travis.yml` rather than have them hidden away in the travis config online.