### PR TITLE
Update water mgmt area job to report errors

### DIFF
--- a/app/jobs/flood_risk_engine/update_water_management_area_job.rb
+++ b/app/jobs/flood_risk_engine/update_water_management_area_job.rb
@@ -18,7 +18,7 @@ module FloodRiskEngine
 
       return process_successful_response(response.areas.first) if response.successful?
 
-      process_unsucessful_response(response)
+      process_unsuccessful_response(response)
     end
 
     def process_successful_response(result)
@@ -32,7 +32,7 @@ module FloodRiskEngine
       end
     end
 
-    def process_unsucessful_response(response)
+    def process_unsuccessful_response(response)
       return WaterManagementArea.outside_england_area if response.error.instance_of?(DefraRuby::Area::NoMatchError)
 
       # Any other error we log it and just return nil


### PR DESCRIPTION
Prior to this change if an error occurred when the engine attempted to lookup the water mangement area for an exemption nothing was logged.

This would mean we on the service team would no longer be aware of any issues with the WFS service until the users reported it.

This change adds reporting of errors to Errbit, and some tweaks to the job class to support it.