### PR TITLE
Fix error in airbrake notification in area lookup

### DIFF
--- a/app/jobs/flood_risk_engine/update_water_management_area_job.rb
+++ b/app/jobs/flood_risk_engine/update_water_management_area_job.rb
@@ -36,8 +36,8 @@ module FloodRiskEngine
       return WaterManagementArea.outside_england_area if response.error.instance_of?(DefraRuby::Area::NoMatchError)
 
       # Any other error we log it and just return nil
-      Airbrake.notify(ex, easting: @location.easting, northing: @location.northing) if defined? Airbrake
-      Rails.logger.error "Update water management area job failed: #{ex}"
+      Airbrake.notify(response.error, easting: @location.easting, northing: @location.northing) if defined? Airbrake
+      Rails.logger.error "Update water management area job failed: #{response.error}"
 
       nil
     end


### PR DESCRIPTION
This was a pretty obvious mistake I let through! 🤦

We have just implemented sending a notification to Airbrake in the event of an error when trying to ascertain the water management area. However when we did we passed `ex` to it.

A quick check of the code and its pretty clear `ex` is never instantiated or exists anywhere. A major copy and paste fail!

So this change resolves the issue and adds a test (more out of embarassment of not catching this the first time).

Whilst in the tests we have also made 2 other changes

- switch the use of `expect` to `allow` for the stubs. When coming back to the code I got a little confused as to whether it was a stub or an expectation, so have renamed them to `allow` to clear up the confusion
- removed the attempts to set the easting and northing on location, its meaningless! This is because the factory always sets the `grid_reference`, and there is a `before_save` hook on `Location` that updates the easting and northing when the grid reference is changed! So they were never actually doing anything in the previous version of the tests