### PR TITLE
Add scopes for finding location for area lookup

### DIFF
--- a/app/models/flood_risk_engine/location.rb
+++ b/app/models/flood_risk_engine/location.rb
@@ -1,11 +1,14 @@
 require "os_map_ref"
+
 module FloodRiskEngine
   class Location < ActiveRecord::Base
-
     belongs_to :locatable, polymorphic: true
     belongs_to :water_management_area
 
     before_save :process_grid_reference
+
+    scope :missing_ea_area, -> { where(water_management_area: nil) }
+    scope :with_easting_and_northing, -> { where.not(easting: [nil, ""], northing: [nil, ""]) }
 
     private
 

--- a/spec/factories/water_management_area_factory.rb
+++ b/spec/factories/water_management_area_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :water_management_area, class: FloodRiskEngine::WaterManagementArea do
+    code { "somewere_in_england" }
+    long_name { "Somewere in England" }
+  end
+end

--- a/spec/models/flood_risk_engine/location_spec.rb
+++ b/spec/models/flood_risk_engine/location_spec.rb
@@ -5,30 +5,55 @@ module FloodRiskEngine
     it { is_expected.to belong_to(:locatable) }
     it { is_expected.to respond_to(:water_management_area) }
 
-    let(:palace) do
-      OpenStruct.new(
-        postcode: "SW1A 1AA",
-        grid_reference: "TQ 29090 79645",
-        easting: "529090",
-        northing: "179645",
-        latitude: 51.501009,
-        longitude: -0.1415876
-      )
-    end
+    context "scopes" do
+      describe ".missing_ea_area" do
+        it "only returns records with a missing area" do
+          missing_ea_area_record = create(:location, water_management_area: nil)
+          create(:location, water_management_area: create(:water_management_area))
 
-    let(:mountain) do
-      OpenStruct.new(
-        postcode: "LL55 4UL",
-        grid_reference: "SH 60992 54374",
-        easting: "260992",
-        northing: "354374",
-        latitude: 53.068468,
-        longitude: -4.0761369
-      )
+          expect(described_class.missing_ea_area).to match_array([missing_ea_area_record])
+        end
+      end
+
+      describe ".with_easting_and_northing" do
+        it "only returns records with both easting and northing defined" do
+          with_easting_and_northing = create(:location, easting: "123.45", northing: "123.45")
+
+          # Bypass before save filter
+          create(:location).update_attributes(easting: "123.45", northing: "")
+          create(:location).update_attributes(easting: "123.45", northing: "")
+          create(:location).update_attributes(easting: "", northing: "123.45")
+          create(:location).update_attributes(easting: "", northing: "123.45")
+          create(:location).update_attributes(easting: nil, northing: nil)
+
+          expect(described_class.with_easting_and_northing).to match_array([with_easting_and_northing])
+        end
+      end
     end
 
     describe "grid reference processing" do
-      let(:location) { Location.create(grid_reference: palace.grid_reference.delete(" ")) }
+      let(:palace) do
+        OpenStruct.new(
+          postcode: "SW1A 1AA",
+          grid_reference: "TQ 29090 79645",
+          easting: "529090",
+          northing: "179645",
+          latitude: 51.501009,
+          longitude: -0.1415876
+        )
+      end
+
+      let(:mountain) do
+        OpenStruct.new(
+          postcode: "LL55 4UL",
+          grid_reference: "SH 60992 54374",
+          easting: "260992",
+          northing: "354374",
+          latitude: 53.068468,
+          longitude: -4.0761369
+        )
+      end
+      let(:location) { create(:location, grid_reference: palace.grid_reference.delete(" ")) }
 
       it "should tidy format of grid reference" do
         expect(location.grid_reference).to eq(palace.grid_reference)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-604

Add scopes to find location without an area but with Easting and Northing info