### PR TITLE
Rename scope and parameter in area lookup job

### DIFF
--- a/app/jobs/flood_risk_engine/update_water_management_area_job.rb
+++ b/app/jobs/flood_risk_engine/update_water_management_area_job.rb
@@ -22,8 +22,8 @@ module FloodRiskEngine
     end
 
     def process_successful_response(area)
-      WaterManagementArea.find_or_create_by(code: area.code) do |area|
-        area.update_attributes(
+      WaterManagementArea.find_or_create_by(code: area.code) do |water_management_area|
+        water_management_area.update_attributes(
           area_id: area.area_id,
           area_name: area.area_name,
           short_name: area.short_name,

--- a/app/jobs/flood_risk_engine/update_water_management_area_job.rb
+++ b/app/jobs/flood_risk_engine/update_water_management_area_job.rb
@@ -21,13 +21,13 @@ module FloodRiskEngine
       process_unsuccessful_response(response)
     end
 
-    def process_successful_response(result)
-      WaterManagementArea.find_or_create_by(code: result.code) do |area|
+    def process_successful_response(area)
+      WaterManagementArea.find_or_create_by(code: area.code) do |area|
         area.update_attributes(
-          area_id: result.area_id,
-          area_name: result.area_name,
-          short_name: result.short_name,
-          long_name: result.long_name
+          area_id: area.area_id,
+          area_name: area.area_name,
+          short_name: area.short_name,
+          long_name: area.long_name
         )
       end
     end

--- a/app/models/flood_risk_engine/location.rb
+++ b/app/models/flood_risk_engine/location.rb
@@ -7,7 +7,7 @@ module FloodRiskEngine
 
     before_save :process_grid_reference
 
-    scope :missing_ea_area, -> { where(water_management_area: nil) }
+    scope :missing_area, -> { where(water_management_area: nil) }
     scope :with_easting_and_northing, -> { where.not(easting: [nil, ""], northing: [nil, ""]) }
 
     private

--- a/spec/models/flood_risk_engine/location_spec.rb
+++ b/spec/models/flood_risk_engine/location_spec.rb
@@ -6,12 +6,12 @@ module FloodRiskEngine
     it { is_expected.to respond_to(:water_management_area) }
 
     context "scopes" do
-      describe ".missing_ea_area" do
+      describe ".missing_area" do
         it "only returns records with a missing area" do
-          missing_ea_area_record = create(:location, water_management_area: nil)
+          missing_area_record = create(:location, water_management_area: nil)
           create(:location, water_management_area: create(:water_management_area))
 
-          expect(described_class.missing_ea_area).to match_array([missing_ea_area_record])
+          expect(described_class.missing_area).to match_array([missing_area_record])
         end
       end
 


### PR DESCRIPTION
Rename the location scope for missing areas to drop the `ea`.
Rename the parameter inside the area lookup method to reflect the actual object the method deals with.