### PR TITLE
Do not generate postcode in address factory

### DIFF
--- a/spec/factories/addresses_factory.rb
+++ b/spec/factories/addresses_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     street_address      Faker::Address.street_address
     locality            Faker::Address.city_prefix
     city                Faker::Address.city
-    postcode            Faker::Address.postcode
+    postcode            "BS1 5AH"
     county_province_id  1
     country_iso         Faker::Address.country_code
     address_type        1
@@ -30,38 +30,8 @@ FactoryBot.define do
     street_address      Faker::Address.street_address
     locality            Faker::Address.city_prefix
     city                Faker::Address.city
-    postcode            { generate :uk_post_code }
+    postcode            "BS1 5AH"
   end
 
   factory :address_services, parent: :address
-
-  # Faker::Address.postcode seems to produce invalid postcodes now & then
-  # so try to bodge our own
-  #     https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom
-  #
-  #
-  #  The letters QVX are not used in the first position.
-  #  The letters IJZ are not used in the second position.
-  #  The only letters to appear in the third position are ABCDEFGHJKPSTUW when the structure starts with A9A.
-  #  The only letters to appear in the fourth position are ABEHMNPRVWXY when the structure starts with AA9A.
-  #  The final two letters do not use the letters CIKMOV, so as not to resemble digits or each other when hand-written.
-  #
-  # rubocop:disable Lint/Loop
-  sequence(:uk_post_code) do |_n|
-    @valid_sequence_1_for_uk_postcode ||= ("A".."Z").to_a - %w[Q V X]
-    @valid_sequence_2_for_uk_postcode ||= ("A".."Y").to_a - %w[I J]
-    @valid_sequence_3_for_uk_postcode ||= ("A".."K").to_a
-    @valid_sequence_4_for_uk_postcode ||= ("A".."Z").to_a - %w[C I K M O V J]
-
-    begin
-      shuffled1 = @valid_sequence_1_for_uk_postcode.shuffle
-      shuffled2 = @valid_sequence_2_for_uk_postcode.shuffle
-      shuffled3 = @valid_sequence_3_for_uk_postcode.shuffle
-      shuffled4 = @valid_sequence_4_for_uk_postcode.shuffle
-
-      pc = UKPostcode.parse("#{shuffled1.first}#{shuffled2.first}#{rand 9} #{rand 9}#{shuffled3.last}#{shuffled4.last}")
-    end until pc.valid?
-    pc.to_s
-  end
-  # rubocop:enable Lint/Loop
 end

--- a/spec/factories/partners_factory.rb
+++ b/spec/factories/partners_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     street_address      { Faker::Address.street_address }
     locality            { Faker::Address.street_address }
     city                { Faker::Address.city }
-    postcode            { generate :uk_post_code }
+    postcode            "BS1 5AH"
   end
 
   factory :partner_contact, class: "FloodRiskEngine::Contact" do


### PR DESCRIPTION
We have found the `spec/lib/tasks/lookups_spec.rb` in the [flood-risk-back-office](https://github.com/DEFRA/flood-risk-back-office) is failing sometimes due to the postcode `Faker::Address.postcode` sometimes returns.

You can also see we've had issues before with invalid or problematic postcodes returned from [Faker](https://github.com/faker-ruby/faker) hence a _whole_ bunch of code to try and generate our own valid postcode.

This change set out to swap the Faker call with a call to `generate_postcode()` however that then caused a test in the engine to always fail (`spec/controllers/flood_risk_engine/enrollments/steps_controller/partnership_details_spec.rb:57` for reference).

😩😩😩

We know the factories and rspec are not set up as we would normally do in our other projects, and at some point we want to update it to be consistent. So it doesn't warrant a deep dive investigation. Also we would not want to change too much in the pursuit of fixing it.

The simple solution is actually just to always use a known valid UK postcode. In this case having a generated valid postcode is not telling us anything a static one cannot, so with this change

- we can always be sure we are getting a known valid postcode
- the logic is simpler
- we get to delete a whole bunch of code that had no tests itself
