### PR TITLE
Add comment about non working address scope

### DIFF
--- a/app/models/flood_risk_engine/location.rb
+++ b/app/models/flood_risk_engine/location.rb
@@ -12,6 +12,11 @@ module FloodRiskEngine
 
     # rubocop:disable Style/Lambda
     # This version of ruby does not like lambdas here
+    # TODO: This scope does not work, though there is nothing wrong with it!
+    # We have uncovered the fact that all addresses are getting added with the
+    # type `:primary`. This means there are no addresses with type `:site`.
+    # We've decided to leave the scope here (because there is nothing wrong
+    # with it) whilst we decide what to do about this issue.
     scope :from_site_address, -> do
       joins("JOIN flood_risk_engine_addresses as addresses ON addresses.id = flood_risk_engine_locations.locatable_id")
         .where("addresses.address_type = ?", 2)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-604

Spotted whilst we were trying to deliver an automated job to update the Area on site locations that are missing one.

We added the scope to ensure we were only updating locations linked to site addresses, but when testing the job we spotted

- there is an existing bug in the service which means the address type is never set to anything other than `:primary`
- locations only get created for site addresses

To fix the area lookup just means reverting the introduction of the scope in the back office, but we decided against deleting the scope altogether. The code is correct and would work of the bug did not exist. So rather than delete something of value, we'll leave it whilst we decide what to do.