### PR TITLE
Lock Byebug version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem "bullet"
   # Call "byebug" anywhere in the code to stop execution and get a debugger
   # console
-  gem "byebug"
+  gem "byebug", "~> 11.0.1" # 11.1 only supports Ruby 2.4 and up
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ DEPENDENCIES
   awesome_print
   bootstrap-sass (~> 3.3)
   bullet
-  byebug
+  byebug (~> 11.0.1)
   capybara (~> 2.6)
   codeclimate-test-reporter
   database_cleaner (~> 1.5)


### PR DESCRIPTION
Dependabot tried to update byebug to 11.1.0 here: https://github.com/DEFRA/flood-risk-engine/pull/320

However we noticed that this version drops support for Ruby 2.3, which this engine is still on.

So for now, we lock the version to stop this update. However we can unlock it when we upgrade our version of Ruby.