### PR TITLE
Fix changelog generator

### DIFF
--- a/lib/tasks/changelog.rake
+++ b/lib/tasks/changelog.rake
@@ -3,4 +3,6 @@
 require "github_changelog_generator/task"
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = "defra"
+  config.project = "flood-risk-engine"
 end


### PR DESCRIPTION
It seems since [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) v1.15.0 dropped last year that the generator has lost the ability to determine the `user` and `project` from the current repo its run in.

Now when we run it we have to call the gem directly and pass these in as arguments to get it to work.

So this change resolves the issue, and means we can go back to using `bundle exec rake changelog`.