### PR TITLE
Add defra-ruby-email to project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activerecord-session_store (~> 1.0)
       defra_ruby_alert (~> 0.1.0)
       defra_ruby_area
+      defra_ruby_email
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       ea-address_lookup (~> 0.3.0)
@@ -113,6 +114,8 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
+    defra_ruby_email (0.2.0)
+      rails (~> 4.2.11.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     dibber (0.6.0)
@@ -205,7 +208,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mini_mime (1.0.2)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ FloodRiskEngine::Engine.routes.draw do
     )
   end
 
+  mount DefraRubyEmail::Engine => "/email"
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 end

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |s|
   s.add_dependency "ea-address_lookup", "~> 0.3.0"
   # Used to determine the EA area for a registered exemption
   s.add_dependency "defra_ruby_area"
+  # Used as part of testing. When enabled adds a /email/last-email route from
+  # which details of the last email sent by the app can be accessed
+  s.add_dependency "defra_ruby_email"
   s.add_dependency "finite_machine", "~> 0.11.3"
   # Enables url obfuscation with 24bit base58 token
   s.add_dependency "has_secure_token", "~> 1.0.0"

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -74,6 +74,13 @@ module FloodRiskEngine
       end
     end
 
+    # Last Email caching and retrieval functionality
+    def use_last_email_cache=(value)
+      DefraRubyEmail.configure do |configuration|
+        configuration.enable = change_string_to_boolean_for(value)
+      end
+    end
+
     private
 
     # If the setting's value is "true", then set to a boolean true. Otherwise, set it to false.

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -4,6 +4,7 @@ require "activerecord/session_store"
 require "high_voltage"
 require "ea/address_lookup"
 require "defra_ruby/area"
+require "defra_ruby_email"
 require "active_support/dependencies"
 require_dependency "virtus"
 


### PR DESCRIPTION
Currently the [Waste Exemptions service](https://github.com/DEFRA/waste-exemptions-engine/pull/112) and the [Waste Carriers Frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/227) have the ability to intercept and play back the details of the last email sent.

This feature is only enabled in our non-production environments and is used as part of our acceptance tests. However our QA @andrewhick has rightly pointed out that the functionality is inconsistent across our services.

Waste Exemptions has it throughout, Waste Carriers only has it in the old app, and Flood Risk Activity Exemptions doesn't have it at all. This makes writing and maintaining acceptance tests across the 3 services difficult and inconsistent so we have been asked to resolve the issue.

Rather than duplicate the existing code even more, we have created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email) a reusable engine that can be mounted into an application to provide the same functionality.

Having created the gem, this change covers adding it to FRAE so it too can benefit from the feature.