### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+dist: trusty
+
 addons:
   postgresql: 9.4
+  sonarcloud:
+    organization: "defra"
 
 env:
   global:
-    - CC_TEST_REPORTER_ID=96b5a7037c20be6bd42f3fdff57e81d68e9074dfd81d079413cb84a8342ba10e
     - ADDRESS_FACADE_CLIENT_ID=0
     - ADDRESS_FACADE_KEY=client1
     - ADDRESS_FACADE_PORT=9002
@@ -17,29 +20,17 @@ language: ruby
 rvm: 2.3.1
 cache: bundler
 
-# Travis CI clones repositories to a depth of 50 commits, which is only really
-# useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
 git:
-  depth: 3
+  depth: false
 
 before_install:
   - export TZ=UTC
   - gem install -v 1.17.3 bundler --no-document
 
 before_script:
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
-  # Run rubocop. It's installed as a dependency (hence no install step) as this
-  # allows projects to control the version they are using (rather than getting)
-  # surprise build failures.
-  - bundle exec rubocop
   # Replace database.yml with database.travis.yml (but leave filename as
   # database.yml). database.travis.yml is the config needed for Travis, and it
   # needs to be in place before we run the migrations.
@@ -47,5 +38,7 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:create --trace
   - RAILS_ENV=test bundle exec rake db:migrate --trace
 
-after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rspec
+  - sonar-scanner

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ end
 
 group :test do
   gem "capybara", "~> 2.6"
-  gem "codeclimate-test-reporter", require: false
   gem "database_cleaner", "~> 1.5"
   gem "email_spec"
   gem "factory_bot_rails", "~> 4.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,8 +97,6 @@ GEM
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
     cliver (0.3.2)
-    codeclimate-test-reporter (1.0.9)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -395,7 +393,6 @@ DEPENDENCIES
   bullet
   byebug (~> 11.0.1)
   capybara (~> 2.6)
-  codeclimate-test-reporter
   database_cleaner (~> 1.5)
   email_spec
   factory_bot_rails (~> 4.7)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Flood risk engine
 
 [![Build Status](https://travis-ci.com/DEFRA/flood-risk-engine.svg?branch=master)](https://travis-ci.com/DEFRA/flood-risk-engine)
-[![Maintainability](https://api.codeclimate.com/v1/badges/275c0c9e2d722dd20837/maintainability)](https://codeclimate.com/github/DEFRA/flood-risk-engine/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/275c0c9e2d722dd20837/test_coverage)](https://codeclimate.com/github/DEFRA/flood-risk-engine/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_flood-risk-engine&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_flood-risk-engine)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_flood-risk-engine&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_flood-risk-engine)
 [![security](https://hakiri.io/github/DEFRA/flood-risk-engine/master.svg)](https://hakiri.io/github/DEFRA/flood-risk-engine/master)
 
 A Ruby on Rails [engine](http://guides.rubyonrails.org/engines.html) delivering the complete public-facing functionality of the [Flood risk activity exemptions service](https://register-flood-risk-exemption.service.gov.uk).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,29 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_flood-risk-engine
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=flood-risk-engine
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/flood-risk-engine
+sonar.links.ci=https://travis-ci.com/DEFRA/flood-risk-engine
+sonar.links.scm=https://github.com/DEFRA/flood-risk-engine
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./app,./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we're about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318