### PR TITLE
Ensure user selects an exemption

### DIFF
--- a/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
+++ b/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
@@ -19,6 +19,19 @@ module FloodRiskEngine
         @all_exemptions = Exemption.all
       end
 
+      def validate(params)
+        # The validation doesn't recognise { exemption_ids: "" } as invalid
+        # As a workaround, we remove any empty hashes from the params
+        # before the validation is actioned
+        super(
+          if params.fetch(params_key, {}).reject { |_, v| v.blank? }.empty?
+            {}
+          else
+            params
+          end
+        )
+      end
+
       def save
         result = super
 

--- a/spec/forms/flood_risk_engine/steps/add_exemptions_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/add_exemptions_form_spec.rb
@@ -60,7 +60,7 @@ module FloodRiskEngine
       end
 
       context "with no exemptions params" do
-        let(:params) { { params_key => {} } }
+        let(:params) { { params_key => { exemption_ids: {} } } }
         it "should fail" do
           expect(subject.validate(params)).to be(false)
         end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1469

- Something to do with the params have changed since the Rails upgrade,
and the validator (add_exemption_form.rb) thinks that
{ exemption_ids: "" } is valid

- The validator specifies min length of 1, but this is voodoo (Reform gem)
validation and it seems to treat the hash as having a length of 1

- This 'fix' removes any param keys without values and seems to 'work'