### PR TITLE
Return correct error for valid postcode without results

### DIFF
--- a/app/forms/flood_risk_engine/steps/base_address_search_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_search_form.rb
@@ -46,7 +46,7 @@ module FloodRiskEngine
 
         return true if response.successful?
 
-        if response.error == DefraRuby::Address::NoMatchError
+        if response.error.is_a?(DefraRuby::Address::NoMatchError)
           handle_no_matching_addresses
           false
         else

--- a/spec/cassettes/address_lookup_no_matches_postcode.yml
+++ b/spec/cassettes/address_lookup_no_matches_postcode.yml
@@ -2,38 +2,36 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=<CLIENT_ID>&key=<CLIENT_ID>&query-string=HR4G%200LE
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=<CLIENT_ID>&key=<CLIENT_ID>&query-string=BS1%201ZZ
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - localhost:9002
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
     headers:
       Date:
-      - Tue, 08 Jun 2021 15:06:32 GMT
+      - Mon, 14 Jun 2021 09:34:10 GMT
       X-Application-Context:
       - application:9002
       Content-Type:
       - application/json
       Content-Length:
-      - '370'
+      - '293'
     body:
       encoding: UTF-8
-      string: '{"facade_status_code":400,"facade_error_message":"bad request to supplier
-        service","facade_error_code":"address_service_error_1","supplier_was_called":true,"supplier_status_code":400,"supplier_response":{"error":{"statuscode":400,"message":"Requested
-        postcode must contain a minimum of the sector plus 1 digit of the district
-        e.g. SO1. Requested postcode was HR4G0LE"}}}'
+      string: '{"header":{"totalMatches":0,"startMatch":null,"endMatch":null,"query":"postcode=BS1
+        1ZZ","language":"EN","dataset":"DPA","epoch":"84","uriToSupplier":"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=BS1%201ZZ&fq=logical_status_code%3A1&dataset=DPA","uriFromClient":""},"results":[]}'
     http_version: 
-  recorded_at: Tue, 08 Jun 2021 15:06:33 GMT
+  recorded_at: Mon, 14 Jun 2021 09:34:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/forms/flood_risk_engine/steps/limited_company_postcode_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/limited_company_postcode_form_spec.rb
@@ -51,17 +51,17 @@ module FloodRiskEngine
       end
 
       context "with invalid params" do
-        let(:valid_but_address_service_400s) {
-          { "#{form.params_key}": { postcode: "HR4G 0LE" } }
+        let(:valid_postcode_no_matches) {
+          { "#{form.params_key}": { postcode: "BS1 1ZZ" } }
         }
 
         it "is invalid when valid Postcode supplied but Address Service finds no matches", duff: true do
           VCR.use_cassette("address_lookup_no_matches_postcode") do
-            expect(form.validate(valid_but_address_service_400s)).to eq false
+            expect(form.validate(valid_postcode_no_matches)).to eq false
 
             expect(
               form.errors.messages[:postcode]
-            ).to eq [I18n.t("flood_risk_engine.validation_errors.postcode.service_unavailable")]
+            ).to eq [I18n.t("flood_risk_engine.validation_errors.postcode.no_addresses_found")]
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1341

Previously if we searched for a postcode with no results, it would display an error message saying that the address finder was not working. This PR fixes the issue so we instead say that no results were found.

I had a look at the spec for this and it was wrong, as it was trying to raise a 400 error which is no longer the response we expect, and then testing for the wrong error message anyway.