### PR TITLE
Clean up duplicate address after address is changed

### DIFF
--- a/app/models/flood_risk_engine/address.rb
+++ b/app/models/flood_risk_engine/address.rb
@@ -39,9 +39,10 @@ module FloodRiskEngine
     private
 
     def clean_up_duplicate_addresses
-      return unless addressable.is_a?(FloodRiskEngine::Organisation)
+      return unless addressable.is_a?(FloodRiskEngine::Organisation) && address_type == "primary"
 
-      primary_addresses = FloodRiskEngine::Address.where(addressable: addressable)
+      primary_addresses = FloodRiskEngine::Address.where(addressable: addressable,
+                                                         address_type: "primary")
 
       primary_addresses.each do |address|
         next if address == self

--- a/app/models/flood_risk_engine/address.rb
+++ b/app/models/flood_risk_engine/address.rb
@@ -8,6 +8,8 @@ module FloodRiskEngine
     belongs_to :addressable, polymorphic: true
     has_one :location, as: :locatable, dependent: :restrict_with_exception
 
+    after_create :clean_up_duplicate_addresses
+
     # Covers the RCDP Types
     #
     enum address_type: {
@@ -32,6 +34,19 @@ module FloodRiskEngine
 
     def address_methods
       %i[premises street_address locality city postcode]
+    end
+
+    private
+
+    def clean_up_duplicate_addresses
+      return unless addressable.is_a?(FloodRiskEngine::Organisation)
+
+      primary_addresses = FloodRiskEngine::Address.where(addressable: addressable)
+
+      primary_addresses.each do |address|
+        next if address == self
+        address.delete
+      end
     end
   end
 end

--- a/spec/factories/enrollments_factory.rb
+++ b/spec/factories/enrollments_factory.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
 
     trait :with_organisation_address do
       after(:build) do |object|
-        object.organisation.primary_address = build :address_services
+        object.organisation.primary_address = build(:address, :primary)
       end
     end
 

--- a/spec/models/flood_risk_engine/address_spec.rb
+++ b/spec/models/flood_risk_engine/address_spec.rb
@@ -31,7 +31,8 @@ module FloodRiskEngine
       let(:org_addresses) { FloodRiskEngine::Address.where(addressable: enrollment.organisation) }
       let(:address) do
         build(:address,
-              postcode: "BS1 1AA")
+              postcode: "BS1 1AA",
+              address_type: :primary)
       end
 
       context "when there are no pre-existing addresses for this enrollment" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1341

During testing we discovered an issue where if an address was added via postcode lookup, and then changed later to one entered manually, the previous address would still be assigned and often displayed instead of the amended, manually-entered version.

To fix this, I've added a callback to clean up any duplicate addresses after a new one is added. The intent is to refactor these forms soon anyway so this is a temporary fix.