### PR TITLE
Add error logging for address lookup service failures

### DIFF
--- a/app/forms/flood_risk_engine/steps/base_address_search_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_search_form.rb
@@ -49,7 +49,7 @@ module FloodRiskEngine
           handle_no_matching_addresses
           false
         else
-          handle_address_service_error
+          handle_address_service_error(response)
           true
         end
       end
@@ -64,7 +64,10 @@ module FloodRiskEngine
         errors.add :postcode, I18n.t("flood_risk_engine.validation_errors.postcode.no_addresses_found")
       end
 
-      def handle_address_service_error
+      def handle_address_service_error(response)
+        Airbrake.notify(response) if defined? Airbrake
+        Rails.logger.error "Address lookup failed: #{response.to_json}"
+
         errors.add :postcode, I18n.t("flood_risk_engine.validation_errors.postcode.service_unavailable")
       end
 

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/postcodes_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/postcodes_spec.rb
@@ -144,8 +144,12 @@ module FloodRiskEngine
               successful?: false,
               error: "foo"
             )
+            allow(Airbrake).to receive(:notify)
 
             expect(FloodRiskEngine::AddressLookupService).to receive(:run).and_return(stub_data)
+
+            expect(Airbrake).to receive(:notify).with(stub_data)
+            expect(Rails.logger).to receive(:error).with("Address lookup failed: #{stub_data.to_json}")
 
             get :show, params: params, session: session
 


### PR DESCRIPTION
We need to be able to log failures for debugging purposes.

This change was previously merged into the Rails 4 main branch here: https://github.com/DEFRA/flood-risk-engine/pull/387