### PR TITLE
Add Simplecov JSON formatter for test coverage in Sonarcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run unit tests
         run: |
           bundle exec rspec spec
-          sed -i 's/\/home\/runner\/work\/flood-risk-engine\/flood-risk-engine\//\/github\/workspace\//g' coverage/.resultset.json
+          sed -i 's/\/home\/runner\/work\/flood-risk-engine\/flood-risk-engine\//\/github\/workspace\//g' coverage/coverage.json
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem "rspec-rails", "~> 5.0.1"
   gem "shoulda-matchers", "~> 4.5.1", require: false
   gem "simplecov", "~> 0.21.2", require: false
+  gem "simplecov_json_formatter", require: false
   gem "vcr", "~> 6.0.0"
   gem "webmock", "~> 3.13"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.4)
   shoulda-matchers (~> 4.5.1)
   simplecov (~> 0.21.2)
+  simplecov_json_formatter
   vcr (~> 6.0.0)
   webmock (~> 3.13)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,5 +25,5 @@ sonar.tests=./spec
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
-sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.coverage.reportPath=coverage/coverage.json
 sonar.ruby.rubocop.reportPaths=rubocop-result.json

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 
 require "simplecov"
+require "simplecov_json_formatter"
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 SimpleCov.start "rails" do
   # any custom configs like groups and filters can be here at a central place
   # Standard filters


### PR DESCRIPTION
As part of the Rails 6 upgrade we updated Simplecov from 0.13 to 0.21. During these version jumps, simplecov got rid of the JSON format output as standard and it instead has to be added through a separate gem. Without this gem, we were unable to export our test coverage to Sonarcloud and it continually reported that we had 0% test coverage.