### PR TITLE
Set up controllers for updated new reg workflow

### DIFF
--- a/app/controllers/concerns/flood_risk_engine/can_redirect_form_to_correct_path.rb
+++ b/app/controllers/concerns/flood_risk_engine/can_redirect_form_to_correct_path.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CanRedirectFormToCorrectPath
+    extend ActiveSupport::Concern
+
+    included do
+      def redirect_to_correct_form
+        redirect_to form_path
+      end
+
+      # Get the path based on the workflow state, with token as params, ie:
+      # new_state_name_path/:token or start_state_name_path?token=:token
+      def form_path
+        send("new_#{@transient_registration.workflow_state}_path".to_sym, token: @transient_registration.token)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/flood_risk_engine/cannot_go_back_form.rb
+++ b/app/controllers/concerns/flood_risk_engine/cannot_go_back_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CannotGoBackForm
+    extend ActiveSupport::Concern
+
+    included do
+      # Override this method as user shouldn't be able to go back from this page
+      def go_back
+        raise ActionController::RoutingError, "Cannot go back"
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/flood_risk_engine/unsubmittable_form.rb
+++ b/app/controllers/concerns/flood_risk_engine/unsubmittable_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module UnsubmittableForm
+    extend ActiveSupport::Concern
+
+    included do
+      # Override this method as user shouldn't be able to "submit" this page
+      def create
+        raise ActionController::RoutingError, "Unsubmittable"
+      end
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/additional_contact_email_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/additional_contact_email_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class AdditionalContactEmailFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(AdditionalContactEmailForm, "additional_contact_email_form")
+    end
+
+    def create
+      super(AdditionalContactEmailForm, "additional_contact_email_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/business_type_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/business_type_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class BusinessTypeFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(BusinessTypeForm, "business_type_form")
+    end
+
+    def create
+      super(BusinessTypeForm, "business_type_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/check_your_answers_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/check_your_answers_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CheckYourAnswersFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CheckYourAnswersForm, "check_your_answers_form")
+    end
+
+    def create
+      super(CheckYourAnswersForm, "check_your_answers_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/company_address_lookup_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_address_lookup_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyAddressLookupFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CompanyAddressLookupForm, "company_address_lookup_form")
+    end
+
+    def create
+      super(CompanyAddressLookupForm, "company_address_lookup_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/company_address_manual_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_address_manual_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyAddressManualFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CompanyAddressManualForm, "company_address_manual_form")
+    end
+
+    def create
+      super(CompanyAddressManualForm, "company_address_manual_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/company_name_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_name_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNameFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CompanyNameForm, "company_name_form")
+    end
+
+    def create
+      super(CompanyNameForm, "company_name_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/company_number_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_number_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNumberFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CompanyNumberForm, "company_number_form")
+    end
+
+    def create
+      super(CompanyNumberForm, "company_number_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/company_postcode_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_postcode_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyPostcodeFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(CompanyPostcodeForm, "company_postcode_form")
+    end
+
+    def create
+      super(CompanyPostcodeForm, "company_postcode_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/confirm_exemption_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/confirm_exemption_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ConfirmExemptionFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(ConfirmExemptionForm, "confirm_exemption_form")
+    end
+
+    def create
+      super(ConfirmExemptionForm, "confirm_exemption_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/contact_email_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_email_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactEmailFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(ContactEmailForm, "contact_email_form")
+    end
+
+    def create
+      super(ContactEmailForm, "contact_email_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/contact_name_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_name_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactNameFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(ContactNameForm, "contact_name_form")
+    end
+
+    def create
+      super(ContactNameForm, "contact_name_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/contact_phone_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_phone_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactPhoneFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(ContactPhoneForm, "contact_phone_form")
+    end
+
+    def create
+      super(ContactPhoneForm, "contact_phone_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/declaration_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/declaration_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class DeclarationFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(DeclarationForm, "declaration_form")
+    end
+
+    def create
+      super(DeclarationForm, "declaration_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/exemption_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/exemption_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ExemptionFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(ExemptionForm, "exemption_form")
+    end
+
+    def create
+      super(ExemptionForm, "exemption_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/forms_controller.rb
+++ b/app/controllers/flood_risk_engine/forms_controller.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class FormsController < ::FloodRiskEngine::ApplicationController
+    include ActionView::Helpers::UrlHelper
+    include CanRedirectFormToCorrectPath
+
+    before_action :back_button_cache_buster
+    before_action :validate_token
+
+    # Expects a form class name (eg BusinessTypeForm) and a snake_case name for the form (eg business_type_form)
+    def new(form_class, form)
+      return false unless set_up_form(form_class, form, params[:token], true)
+
+      fetch_presenters
+
+      # Return 'true' by default so the `return unless super(...)` bits in
+      # subclassed controllers don't fail.
+      true
+    end
+
+    # Expects a form class name (eg BusinessTypeForm) and a snake_case name for the form (eg business_type_form)
+    def create(form_class, form)
+      return false unless set_up_form(form_class, form, params[:token])
+
+      fetch_presenters
+
+      submit_form(instance_variable_get("@#{form}"), transient_registration_attributes)
+    end
+
+    def go_back
+      find_or_initialize_transient_registration(params[:token])
+
+      @transient_registration.back! if form_matches_state?
+      redirect_to_correct_form
+    end
+
+    private
+
+    def transient_registration_attributes
+      # Default behavuour - permit no params
+      # Override in subclasses when needed
+      params.permit
+    end
+
+    def validate_token
+      return redirect_to(page_path("invalid")) unless find_or_initialize_transient_registration(params[:token])
+    end
+
+    def find_or_initialize_transient_registration(token)
+      @transient_registration ||= TransientRegistration.where(token: token).first
+    end
+
+    # Expects a form class name (eg BusinessTypeForm), a snake_case name for the form (eg business_type_form),
+    # and the token param
+    def set_up_form(form_class, form, token, get_request = false)
+      find_or_initialize_transient_registration(token)
+
+      set_workflow_state if get_request
+
+      return false unless setup_checks_pass?
+
+      # Set an instance variable for the form (eg. @business_type_form) using the provided class (eg. BusinessTypeForm)
+      instance_variable_set("@#{form}", form_class.new(@transient_registration))
+    end
+
+    def submit_form(form, params)
+      respond_to do |format|
+        if form.submit(params)
+          @transient_registration.next!
+          format.html { redirect_to_correct_form }
+          true
+        else
+          format.html { render :new }
+          false
+        end
+      end
+    end
+
+    def setup_checks_pass?
+      return true if state_is_correct?
+
+      redirect_to page_path(result.error_state)
+    end
+
+    def set_workflow_state
+      return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
+      return unless state_can_navigate_flexibly?(requested_state)
+      return unless @transient_registration.persisted?
+
+      @transient_registration.update_attributes(workflow_state: requested_state)
+    end
+
+    def state_can_navigate_flexibly?(state)
+      form_class = FloodRiskEngine.const_get(state.camelize)
+      form_class.can_navigate_flexibly?
+    end
+
+    def requested_state
+      # Get the controller_name, excluding the last character (for example, changing location_forms to location_form)
+      controller_name[0..-2]
+    end
+
+    # Guards
+    def state_is_correct?
+      return true if form_matches_state?
+
+      redirect_to_correct_form
+      false
+    end
+
+    def form_matches_state?
+      controller_name == "#{@transient_registration.workflow_state}s"
+    end
+
+    # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
+    def back_button_cache_buster
+      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+
+    def fetch_presenters
+      # A little hook to set up presenters used by the forms. Intended to be
+      # overwritten in subclasses when a presenter is required.
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/partner_address_lookup_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/partner_address_lookup_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerAddressLookupFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(PartnerAddressLookupForm, "partner_address_lookup_form")
+    end
+
+    def create
+      super(PartnerAddressLookupForm, "partner_address_lookup_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/partner_address_manual_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/partner_address_manual_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerAddressManualFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(PartnerAddressManualForm, "partner_address_manual_form")
+    end
+
+    def create
+      super(PartnerAddressManualForm, "partner_address_manual_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/partner_name_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/partner_name_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerNameFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(PartnerNameForm, "partner_name_form")
+    end
+
+    def create
+      super(PartnerNameForm, "partner_name_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/partner_overview_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/partner_overview_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerOverviewFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(PartnerOverviewForm, "partner_overview_form")
+    end
+
+    def create
+      super(PartnerOverviewForm, "partner_overview_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/partner_postcode_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/partner_postcode_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerPostcodeFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(PartnerPostcodeForm, "partner_postcode_form")
+    end
+
+    def create
+      super(PartnerPostcodeForm, "partner_postcode_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class RegistrationCompleteFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(RegistrationCompleteForm, "registration_complete_form")
+    end
+
+    def create; end
+  end
+end

--- a/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
@@ -2,10 +2,11 @@
 
 module FloodRiskEngine
   class RegistrationCompleteFormsController < ::FloodRiskEngine::FormsController
+    include UnsubmittableForm
+    include CannotGoBackForm
+
     def new
       super(RegistrationCompleteForm, "registration_complete_form")
     end
-
-    def create; end
   end
 end

--- a/app/controllers/flood_risk_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/site_grid_reference_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class SiteGridReferenceFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(SiteGridReferenceForm, "site_grid_reference_form")
+    end
+
+    def create
+      super(SiteGridReferenceForm, "site_grid_reference_form")
+    end
+  end
+end

--- a/app/controllers/flood_risk_engine/start_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/start_forms_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class StartFormsController < ::FloodRiskEngine::FormsController
+    def new
+      super(StartForm, "start_form")
+    end
+
+    def create
+      super(StartForm, "start_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:start_form, {}).permit(:temp_start_option)
+    end
+
+    def find_or_initialize_transient_registration(token)
+      @transient_registration = NewRegistration.where(token: token).first ||
+                                NewRegistration.new
+    end
+
+  end
+end

--- a/app/forms/flood_risk_engine/additional_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/additional_contact_email_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class AdditionalContactEmailForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/base_form.rb
+++ b/app/forms/flood_risk_engine/base_form.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class BaseForm
+    include ActiveModel::Model
+    include CanStripWhitespace
+
+    extend ActiveModel::Callbacks
+
+    attr_reader :transient_registration
+
+    # If the record is new, and not yet persisted (which it is when the start
+    # page is first submitted) then we have nothing to validate, hence the check.
+    # Registrations also don't have tokens, so don't try to validate them.
+    validates :token, presence: true, if: lambda {
+      transient_registration&.persisted? &&
+        transient_registration&.is_a?(TransientRegistration)
+    }
+
+    validate :transient_registration_valid?
+
+    define_model_callbacks :initialize
+
+    # The standard behaviour for loading a form is to check whether the requested form matches the workflow_state for
+    # the registration, and redirect to the saved workflow_state if it doesn't.
+    # But if the workflow state is 'flexible', we skip the check and load the requested form instead of the saved one.
+    # This means users can still navigate by using the browser back button and reload forms which don't match the
+    # saved workflow_state. We then update the workflow_state to match their request, rather than the other way around.
+    # These are generally forms after 'start_form' but before 'declaration_form'.
+    # Any form objects including this concern are considered to be 'flexible' by the FormsController.
+    def self.can_navigate_flexibly?
+      # This can be overriden in a subclass if one requires the avoidance of flexible navigation.
+      true
+    end
+
+    def initialize(transient_registration)
+      run_callbacks :initialize do
+        # Get values from transient registration so form will be pre-filled
+        @transient_registration = transient_registration
+      end
+    end
+
+    def submit(attributes)
+      attributes = strip_whitespace(attributes)
+
+      transient_registration.assign_attributes(attributes)
+
+      return transient_registration.save! if valid?
+
+      false
+    end
+
+    def token
+      # Registrations don't have tokens, so don't try to delegate.
+      return unless transient_registration&.is_a?(TransientRegistration)
+
+      transient_registration.token
+    end
+
+    private
+
+    def transient_registration_valid?
+      return if transient_registration.valid?
+
+      transient_registration.errors.each_value do |message|
+        errors[:base] << message
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/business_type_form.rb
+++ b/app/forms/flood_risk_engine/business_type_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class BusinessTypeForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/check_your_answers_form.rb
+++ b/app/forms/flood_risk_engine/check_your_answers_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CheckYourAnswersForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/company_address_lookup_form.rb
+++ b/app/forms/flood_risk_engine/company_address_lookup_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyAddressLookupForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/company_address_manual_form.rb
+++ b/app/forms/flood_risk_engine/company_address_manual_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyAddressManualForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/company_name_form.rb
+++ b/app/forms/flood_risk_engine/company_name_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNameForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/company_number_form.rb
+++ b/app/forms/flood_risk_engine/company_number_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNumberForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/company_postcode_form.rb
+++ b/app/forms/flood_risk_engine/company_postcode_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyPostcodeForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/confirm_exemption_form.rb
+++ b/app/forms/flood_risk_engine/confirm_exemption_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ConfirmExemptionForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/contact_email_form.rb
+++ b/app/forms/flood_risk_engine/contact_email_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactEmailForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/contact_name_form.rb
+++ b/app/forms/flood_risk_engine/contact_name_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactNameForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/contact_phone_form.rb
+++ b/app/forms/flood_risk_engine/contact_phone_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactPhoneForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/declaration_form.rb
+++ b/app/forms/flood_risk_engine/declaration_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class DeclarationForm < ::FloodRiskEngine::BaseForm
+    def self.can_navigate_flexibly?
+      false
+    end
+
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/exemption_form.rb
+++ b/app/forms/flood_risk_engine/exemption_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ExemptionForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/partner_address_lookup_form.rb
+++ b/app/forms/flood_risk_engine/partner_address_lookup_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerAddressLookupForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/partner_address_manual_form.rb
+++ b/app/forms/flood_risk_engine/partner_address_manual_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerAddressManualForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/partner_name_form.rb
+++ b/app/forms/flood_risk_engine/partner_name_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerNameForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/partner_overview_form.rb
+++ b/app/forms/flood_risk_engine/partner_overview_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerOverviewForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/partner_postcode_form.rb
+++ b/app/forms/flood_risk_engine/partner_postcode_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class PartnerPostcodeForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/registration_complete_form.rb
+++ b/app/forms/flood_risk_engine/registration_complete_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class RegistrationCompleteForm < ::FloodRiskEngine::BaseForm
+    def self.can_navigate_flexibly?
+      false
+    end
+
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/site_grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/site_grid_reference_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class SiteGridReferenceForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/start_form.rb
+++ b/app/forms/flood_risk_engine/start_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class StartForm < ::FloodRiskEngine::BaseForm
+    def submit(_params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      attributes = {}
+
+      super(attributes)
+    end
+  end
+end

--- a/app/models/concerns/flood_risk_engine/can_strip_whitespace.rb
+++ b/app/models/concerns/flood_risk_engine/can_strip_whitespace.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  # Used to clean up excess whitespace from the start and end of fields
+  module CanStripWhitespace
+    extend ActiveSupport::Concern
+
+    # Expects a hash of attributes or a Mongoid object
+    def strip_whitespace(attributes)
+      # Loop over each value and strip the whitespace, or strip the whitespace from values nested within it
+      attributes.each_pair do |key, value|
+        if value.is_a?(String)
+          attributes[key] = strip_string(value)
+        elsif value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+          strip_hash(value)
+        elsif value.is_a?(Array)
+          strip_array(value)
+        end
+      end
+    end
+
+    private
+
+    def strip_string(string)
+      string.strip
+    end
+
+    def strip_hash(hash)
+      strip_whitespace(hash)
+    end
+
+    def strip_array(array)
+      array.each do |nested_object|
+        strip_whitespace(nested_object.attributes) if nested_object.respond_to?(:attributes)
+      end
+    end
+  end
+end

--- a/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@additional_contact_email_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @additional_contact_email_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @additional_contact_email_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_additional_contact_email_forms_path(@additional_contact_email_form.token)) %>
+
 <div class="text">
   <%= form_for(@additional_contact_email_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @additional_contact_email_form) %>

--- a/app/views/flood_risk_engine/business_type_forms/new.html.erb
+++ b/app/views/flood_risk_engine/business_type_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@business_type_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @business_type_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @business_type_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/business_type_forms/new.html.erb
+++ b/app/views/flood_risk_engine/business_type_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_business_type_forms_path(@business_type_form.token)) %>
+
 <div class="text">
   <%= form_for(@business_type_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @business_type_form) %>

--- a/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_check_your_answers_forms_path(@check_your_answers_form.token)) %>
+
 <div class="text">
   <%= form_for(@check_your_answers_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @check_your_answers_form) %>

--- a/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@check_your_answers_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @check_your_answers_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @check_your_answers_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/company_address_lookup_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_address_lookup_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_company_address_lookup_forms_path(@company_address_lookup_form.token)) %>
+
 <div class="text">
   <%= form_for(@company_address_lookup_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @company_address_lookup_form) %>

--- a/app/views/flood_risk_engine/company_address_lookup_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_address_lookup_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@company_address_lookup_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @company_address_lookup_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @company_address_lookup_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/company_address_manual_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_address_manual_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@company_address_manual_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @company_address_manual_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @company_address_manual_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/company_address_manual_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_address_manual_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_company_address_manual_forms_path(@company_address_manual_form.token)) %>
+
 <div class="text">
   <%= form_for(@company_address_manual_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @company_address_manual_form) %>

--- a/app/views/flood_risk_engine/company_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_name_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_company_name_forms_path(@company_name_form.token)) %>
+
 <div class="text">
   <%= form_for(@company_name_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @company_name_form) %>

--- a/app/views/flood_risk_engine/company_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_name_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@company_name_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @company_name_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @company_name_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/company_number_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_number_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@company_number_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @company_number_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @company_number_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/company_number_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_number_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_company_number_forms_path(@company_number_form.token)) %>
+
 <div class="text">
   <%= form_for(@company_number_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @company_number_form) %>

--- a/app/views/flood_risk_engine/company_postcode_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_postcode_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_company_postcode_forms_path(@company_postcode_form.token)) %>
+
 <div class="text">
   <%= form_for(@company_postcode_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @company_postcode_form) %>

--- a/app/views/flood_risk_engine/company_postcode_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_postcode_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@company_postcode_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @company_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @company_postcode_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@confirm_exemption_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @confirm_exemption_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @confirm_exemption_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_confirm_exemption_forms_path(@confirm_exemption_form.token)) %>
+
 <div class="text">
   <%= form_for(@confirm_exemption_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @confirm_exemption_form) %>

--- a/app/views/flood_risk_engine/contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_email_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@contact_email_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @contact_email_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @contact_email_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_email_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_contact_email_forms_path(@contact_email_form.token)) %>
+
 <div class="text">
   <%= form_for(@contact_email_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @contact_email_form) %>

--- a/app/views/flood_risk_engine/contact_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_name_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_contact_name_forms_path(@contact_name_form.token)) %>
+
 <div class="text">
   <%= form_for(@contact_name_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @contact_name_form) %>

--- a/app/views/flood_risk_engine/contact_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_name_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@contact_name_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @contact_name_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @contact_name_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_contact_phone_forms_path(@contact_phone_form.token)) %>
+
 <div class="text">
   <%= form_for(@contact_phone_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @contact_phone_form) %>

--- a/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@contact_phone_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @contact_phone_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @contact_phone_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/declaration_forms/new.html.erb
+++ b/app/views/flood_risk_engine/declaration_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@declaration_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @declaration_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @declaration_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/declaration_forms/new.html.erb
+++ b/app/views/flood_risk_engine/declaration_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_declaration_forms_path(@declaration_form.token)) %>
+
 <div class="text">
   <%= form_for(@declaration_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @declaration_form) %>

--- a/app/views/flood_risk_engine/exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/exemption_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@exemption_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @exemption_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @exemption_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/exemption_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_exemption_forms_path(@exemption_form.token)) %>
+
 <div class="text">
   <%= form_for(@exemption_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @exemption_form) %>

--- a/app/views/flood_risk_engine/partner_address_lookup_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_address_lookup_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@partner_address_lookup_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @partner_address_lookup_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @partner_address_lookup_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/partner_address_lookup_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_address_lookup_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_partner_address_lookup_forms_path(@partner_address_lookup_form.token)) %>
+
 <div class="text">
   <%= form_for(@partner_address_lookup_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @partner_address_lookup_form) %>

--- a/app/views/flood_risk_engine/partner_address_manual_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_address_manual_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@partner_address_manual_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @partner_address_manual_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @partner_address_manual_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/partner_address_manual_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_address_manual_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_partner_address_manual_forms_path(@partner_address_manual_form.token)) %>
+
 <div class="text">
   <%= form_for(@partner_address_manual_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @partner_address_manual_form) %>

--- a/app/views/flood_risk_engine/partner_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_name_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_partner_name_forms_path(@partner_name_form.token)) %>
+
 <div class="text">
   <%= form_for(@partner_name_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @partner_name_form) %>

--- a/app/views/flood_risk_engine/partner_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_name_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@partner_name_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @partner_name_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @partner_name_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_partner_overview_forms_path(@partner_overview_form.token)) %>
+
 <div class="text">
   <%= form_for(@partner_overview_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @partner_overview_form) %>

--- a/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@partner_overview_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @partner_overview_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @partner_overview_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/partner_postcode_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_postcode_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@partner_postcode_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @partner_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @partner_postcode_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/partner_postcode_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_postcode_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_partner_postcode_forms_path(@partner_postcode_form.token)) %>
+
 <div class="text">
   <%= form_for(@partner_postcode_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @partner_postcode_form) %>

--- a/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
+++ b/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
@@ -5,9 +5,5 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <%= hidden_field_tag :token, @registration_complete_form.token %>
-
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
   <% end %>
 </div>

--- a/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
+++ b/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@registration_complete_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @registration_complete_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @registration_complete_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/shared/_back.html.erb
+++ b/app/views/flood_risk_engine/shared/_back.html.erb
@@ -1,0 +1,1 @@
+<%= link_to(t(".back_link"), back_path, class: "link-back") %>

--- a/app/views/flood_risk_engine/shared/_errors.html.erb
+++ b/app/views/flood_risk_engine/shared/_errors.html.erb
@@ -1,0 +1,11 @@
+<% if object.errors.any? %>
+<div class="error-summary" role="alert">
+  <h2 class="heading-medium error-summary-heading"><%= t(".heading") %></h2>
+
+  <ul class="error-summary-list">
+    <% object.errors.each do |field, message| %>
+      <li><a href="#<%= field %>" data-turbolinks="false"><%= message %></a></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>

--- a/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@site_grid_reference_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @site_grid_reference_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @site_grid_reference_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
@@ -1,3 +1,5 @@
+<%= render("flood_risk_engine/shared/back", back_path: back_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
+
 <div class="text">
   <%= form_for(@site_grid_reference_form) do |f| %>
     <%= render("flood_risk_engine/shared/errors", object: @site_grid_reference_form) %>

--- a/app/views/flood_risk_engine/start_forms/new.html.erb
+++ b/app/views/flood_risk_engine/start_forms/new.html.erb
@@ -1,0 +1,13 @@
+<div class="text">
+  <%= form_for(@start_form) do |f| %>
+    <%= render("flood_risk_engine/shared/errors", object: @start_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= hidden_field_tag :token, @start_form.token %>
+
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  flood_risk_engine:
+    shared:
+      back:
+        back_link: Back
+      errors:
+        heading: A problem to fix
   time:
     formats:
       short: "%d %b %Y"
@@ -22,4 +28,3 @@ en:
   global:
     back: Back
     continue: Continue
-

--- a/config/locales/flood_risk_engine/additional_contact_email_forms.en.yml
+++ b/config/locales/flood_risk_engine/additional_contact_email_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    additional_contact_email_forms:
+      new:
+        heading: "Additional contact email"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/business_type_forms.en.yml
+++ b/config/locales/flood_risk_engine/business_type_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    business_type_forms:
+      new:
+        heading: "Business type"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
+++ b/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    check_your_answers_forms:
+      new:
+        heading: "Check your answers"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/company_address_lookup_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_address_lookup_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    company_address_lookup_forms:
+      new:
+        heading: "Company address lookup"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/company_address_manual_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_address_manual_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    company_address_manual_forms:
+      new:
+        heading: "Company address (manual entry)"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/company_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_name_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    company_name_forms:
+      new:
+        heading: "Company name"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/company_number_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_number_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    company_number_forms:
+      new:
+        heading: "company_number"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/company_postcode_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_postcode_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    company_postcode_forms:
+      new:
+        heading: "Company postcode"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    confirm_exemption_forms:
+      new:
+        heading: "Confirm exemption"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/contact_email_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_email_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    contact_email_forms:
+      new:
+        heading: "Contact email"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/contact_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_name_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    contact_name_forms:
+      new:
+        heading: "Contact name"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/contact_phone_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_phone_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    contact_phone_forms:
+      new:
+        heading: "Contact phone"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/declaration_forms.en.yml
+++ b/config/locales/flood_risk_engine/declaration_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    declaration_forms:
+      new:
+        heading: "Declaration"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/exemption_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    exemption_forms:
+      new:
+        heading: "Select exemption"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/partner_address_lookup_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_address_lookup_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    partner_address_lookup_forms:
+      new:
+        heading: "Partner address lookup"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/partner_address_manual_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_address_manual_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    partner_address_manual_forms:
+      new:
+        heading: "Partner address (manual entry)"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/partner_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_name_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    partner_name_forms:
+      new:
+        heading: "Partner name"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/partner_overview_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_overview_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    partner_overview_forms:
+      new:
+        heading: "Partner overview"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/partner_postcode_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_postcode_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    partner_postcode_forms:
+      new:
+        heading: "Partner postcode"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/registration_complete_forms.en.yml
+++ b/config/locales/flood_risk_engine/registration_complete_forms.en.yml
@@ -1,0 +1,5 @@
+en:
+  flood_risk_engine:
+    registration_complete_forms:
+      new:
+        heading: "Registration complete"

--- a/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
+++ b/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    site_grid_reference_forms:
+      new:
+        heading: "Site grid reference"
+        next_button: "Submit"

--- a/config/locales/flood_risk_engine/start_forms.en.yml
+++ b/config/locales/flood_risk_engine/start_forms.en.yml
@@ -1,0 +1,6 @@
+en:
+  flood_risk_engine:
+    start_forms:
+      new:
+        heading: "Start"
+        next_button: "Submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,22 @@
 FloodRiskEngine::Engine.routes.draw do
+  resources :start_forms,
+            only: %i[new create],
+            path: "start",
+            path_names: { new: "" }
+
+  scope "/:token" do
+    # New registration flow
+    resources :exemption_forms,
+              only: %i[new create],
+              path: "exemption",
+              path_names: { new: "" } do
+                get "back",
+                    to: "exemption_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+  end
+
   resources :enrollments, only: [:new, :create] do
     resources :steps,      only: [:show, :update],  controller: "enrollments/steps"
     resources :exemptions, only: [:destroy, :show], controller: "enrollments/exemptions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,201 @@ FloodRiskEngine::Engine.routes.draw do
                     as: "back",
                     on: :collection
               end
+
+    resources :confirm_exemption_forms,
+              only: %i[new create],
+              path: "confirm_exemption",
+              path_names: { new: "" } do
+                get "back",
+                    to: "confirm_exemption_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :site_grid_reference_forms,
+              only: %i[new create],
+              path: "site-grid-reference",
+              path_names: { new: "" } do
+                get "back",
+                    to: "site_grid_reference_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :business_type_forms,
+              only: %i[new create],
+              path: "business-type",
+              path_names: { new: "" } do
+                get "back",
+                    to: "business_type_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :company_number_forms,
+              only: %i[new create],
+              path: "company-number",
+              path_names: { new: "" } do
+                get "back",
+                    to: "company_number_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :company_name_forms,
+              only: %i[new create],
+              path: "company-name",
+              path_names: { new: "" } do
+                get "back",
+                    to: "company_name_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :company_postcode_forms,
+              only: %i[new create],
+              path: "company-postcode",
+              path_names: { new: "" } do
+                get "back",
+                    to: "company_postcode_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :company_address_lookup_forms,
+              only: %i[new create],
+              path: "company-address-lookup",
+              path_names: { new: "" } do
+                get "back",
+                    to: "company_address_lookup_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :company_address_manual_forms,
+              only: %i[new create],
+              path: "company-address-manual",
+              path_names: { new: "" } do
+                get "back",
+                    to: "company_address_manual_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :partner_name_forms,
+              only: %i[new create],
+              path: "partner-name",
+              path_names: { new: "" } do
+                get "back",
+                    to: "partner_name_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :partner_postcode_forms,
+              only: %i[new create],
+              path: "partner-postcode",
+              path_names: { new: "" } do
+                get "back",
+                    to: "partner_postcode_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :partner_address_lookup_forms,
+              only: %i[new create],
+              path: "partner-address-lookup",
+              path_names: { new: "" } do
+                get "back",
+                    to: "partner_address_lookup_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :partner_address_manual_forms,
+              only: %i[new create],
+              path: "partner-address-manual",
+              path_names: { new: "" } do
+                get "back",
+                    to: "partner_address_manual_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :partner_overview_forms,
+              only: %i[new create],
+              path: "partner-overview",
+              path_names: { new: "" } do
+                get "back",
+                    to: "partner_overview_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :contact_name_forms,
+              only: %i[new create],
+              path: "contact-name",
+              path_names: { new: "" } do
+                get "back",
+                    to: "contact_name_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :contact_phone_forms,
+              only: %i[new create],
+              path: "contact-phone",
+              path_names: { new: "" } do
+                get "back",
+                    to: "contact_phone_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :contact_email_forms,
+              only: %i[new create],
+              path: "contact-email",
+              path_names: { new: "" } do
+                get "back",
+                    to: "contact_email_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :additional_contact_email_forms,
+              only: %i[new create],
+              path: "additional-contact-email",
+              path_names: { new: "" } do
+                get "back",
+                    to: "additional_contact_email_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :check_your_answers_forms,
+              only: %i[new create],
+              path: "check-your-answers",
+              path_names: { new: "" } do
+                get "back",
+                    to: "check_your_answers_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :declaration_forms,
+              only: %i[new create],
+              path: "declaration",
+              path_names: { new: "" } do
+                get "back",
+                    to: "declaration_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
+    resources :registration_complete_forms,
+              only: %i[new create],
+              path: "registration-complete",
+              path_names: { new: "" }
   end
 
   resources :enrollments, only: [:new, :create] do
@@ -39,4 +234,7 @@ FloodRiskEngine::Engine.routes.draw do
 
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
+
+  # Static pages with HighVoltage
+  resources :pages, only: [:show], controller: "pages"
 end

--- a/db/migrate/20210624113422_add_type_to_transient_registrations.rb
+++ b/db/migrate/20210624113422_add_type_to_transient_registrations.rb
@@ -1,0 +1,14 @@
+class AddTypeToTransientRegistrations < ActiveRecord::Migration[6.0]
+  def up
+    add_column :transient_registrations, :type, :string, null: false
+    # Set any existing TransientRegistrations to NewRegistrations so everything has a type
+    execute <<-SQL
+       UPDATE transient_registrations
+       SET type = 'FloodRiskEngine::NewRegistration';
+    SQL
+  end
+
+  def down
+    remove_column :transient_registrations, :type
+  end
+end

--- a/db/migrate/20210624113422_add_type_to_transient_registrations.rb
+++ b/db/migrate/20210624113422_add_type_to_transient_registrations.rb
@@ -1,11 +1,13 @@
 class AddTypeToTransientRegistrations < ActiveRecord::Migration[6.0]
   def up
-    add_column :transient_registrations, :type, :string, null: false
+    add_column :transient_registrations, :type, :string, default: "FloodRiskEngine::NewRegistration"
     # Set any existing TransientRegistrations to NewRegistrations so everything has a type
     execute <<-SQL
        UPDATE transient_registrations
        SET type = 'FloodRiskEngine::NewRegistration';
     SQL
+
+    change_column_null :transient_registrations, :type, false
   end
 
   def down

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_101800) do
+ActiveRecord::Schema.define(version: 2021_06_24_113422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,6 +221,7 @@ ActiveRecord::Schema.define(version: 2021_06_21_101800) do
   create_table "transient_registrations", force: :cascade do |t|
     t.string "token"
     t.string "workflow_state"
+    t.string "type", null: false
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 2021_06_24_113422) do
   create_table "transient_registrations", force: :cascade do |t|
     t.string "token"
     t.string "workflow_state"
-    t.string "type", null: false
+    t.string "type", default: "FloodRiskEngine::NewRegistration", null: false
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,6 +93,10 @@ RSpec.configure do |config|
 
   require_relative "support/spec_controller_helpers"
   config.include SpecControllerHelpers, type: :controller
+
+  config.before :each, type: :request do
+    config.include FloodRiskEngine::Engine.routes.url_helpers
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/flood_risk_engine/additional_contact_email_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/additional_contact_email_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "AdditionalContactEmailForms", type: :request do
+    include_examples "GET flexible form", "additional_contact_email_form"
+
+    include_examples "POST without params form", "additional_contact_email_form"
+
+    describe "GET back_additional_contact_email_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "additional_contact_email_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the contact_email form" do
+            get back_additional_contact_email_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_contact_email_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_additional_contact_email_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/business_type_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/business_type_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "BusinessTypeForms", type: :request do
+    include_examples "GET flexible form", "business_type_form"
+
+    include_examples "POST without params form", "business_type_form"
+
+    describe "GET back_business_type_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "business_type_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the site_grid_reference form" do
+            get back_business_type_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_site_grid_reference_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_business_type_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/check_your_answers_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/check_your_answers_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CheckYourAnswersForms", type: :request do
+    include_examples "GET flexible form", "check_your_answers_form"
+
+    include_examples "POST without params form", "check_your_answers_form"
+
+    describe "GET back_check_your_answers_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "check_your_answers_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the additional_contact_email form" do
+            get back_check_your_answers_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_additional_contact_email_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_check_your_answers_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/company_address_lookup_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_address_lookup_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CompanyAddressLookupForms", type: :request do
+    include_examples "GET flexible form", "company_address_lookup_form"
+
+    include_examples "POST without params form", "company_address_lookup_form"
+
+    describe "GET back_company_address_lookup_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_address_lookup_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the company_postcode form" do
+            get back_company_address_lookup_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_company_postcode_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_company_address_lookup_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/company_address_manual_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_address_manual_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CompanyAddressManualForms", type: :request do
+    include_examples "GET flexible form", "company_address_manual_form"
+
+    include_examples "POST without params form", "company_address_manual_form"
+
+    describe "GET back_company_address_manual_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_address_manual_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the company_postcode form" do
+            get back_company_address_manual_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_company_postcode_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_company_address_manual_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/company_name_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_name_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CompanyNameForms", type: :request do
+    include_examples "GET flexible form", "company_name_form"
+
+    include_examples "POST without params form", "company_name_form"
+
+    describe "GET back_company_name_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the business_type form" do
+            get back_company_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_company_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/company_number_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_number_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CompanyNumberForms", type: :request do
+    include_examples "GET flexible form", "company_number_form"
+
+    include_examples "POST without params form", "company_number_form"
+
+    describe "GET back_company_number_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_number_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the business_type form" do
+            get back_company_number_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_company_number_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_postcode_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "CompanyPostcodeForms", type: :request do
+    include_examples "GET flexible form", "company_postcode_form"
+
+    include_examples "POST without params form", "company_postcode_form"
+
+    describe "GET back_company_postcode_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_postcode_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the company_name form" do
+            get back_company_postcode_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_company_postcode_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/confirm_exemption_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/confirm_exemption_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "ConfirmExemptionForms", type: :request do
+    include_examples "GET flexible form", "confirm_exemption_form"
+
+    include_examples "POST without params form", "confirm_exemption_form"
+
+    describe "GET back_confirm_exemption_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "confirm_exemption_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the exemption form" do
+            get back_confirm_exemption_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_exemption_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_confirm_exemption_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/contact_email_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_email_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "ContactEmailForms", type: :request do
+    include_examples "GET flexible form", "contact_email_form"
+
+    include_examples "POST without params form", "contact_email_form"
+
+    describe "GET back_contact_email_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "contact_email_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the contact_phone form" do
+            get back_contact_email_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_contact_phone_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_contact_email_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/contact_name_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_name_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "ContactNameForms", type: :request do
+    include_examples "GET flexible form", "contact_name_form"
+
+    include_examples "POST without params form", "contact_name_form"
+
+    describe "GET back_contact_name_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "contact_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the company_address_lookup form" do
+            get back_contact_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_company_address_lookup_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_contact_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_phone_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "ContactPhoneForms", type: :request do
+    include_examples "GET flexible form", "contact_phone_form"
+
+    include_examples "POST without params form", "contact_phone_form"
+
+    describe "GET back_contact_phone_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "contact_phone_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the contact_name form" do
+            get back_contact_phone_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_contact_phone_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/declaration_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/declaration_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "DeclarationForms", type: :request do
+    include_examples "GET locked-in form", "declaration_form"
+
+    include_examples "POST without params form", "declaration_form"
+
+    describe "GET back_declaration_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the check_your_answers form" do
+            get back_declaration_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_check_your_answers_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "company_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_declaration_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/exemption_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/exemption_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "ExemptionForms", type: :request do
+    include_examples "GET flexible form", "exemption_form"
+
+    include_examples "POST without params form", "exemption_form"
+
+    describe "GET back_exemption_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "exemption_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the start form" do
+            get back_exemption_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_start_form_path(token: transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_exemption_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/partner_address_lookup_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_address_lookup_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "PartnerAddressLookupForms", type: :request do
+    include_examples "GET flexible form", "partner_address_lookup_form"
+
+    include_examples "POST without params form", "partner_address_lookup_form"
+
+    describe "GET back_partner_address_lookup_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "partner_address_lookup_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the partner_postcode form" do
+            get back_partner_address_lookup_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_partner_postcode_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_partner_address_lookup_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/partner_address_manual_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_address_manual_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "PartnerAddressManualForms", type: :request do
+    include_examples "GET flexible form", "partner_address_manual_form"
+
+    include_examples "POST without params form", "partner_address_manual_form"
+
+    describe "GET back_partner_address_manual_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "partner_address_manual_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the partner_postcode form" do
+            get back_partner_address_manual_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_partner_postcode_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_partner_address_manual_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/partner_name_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_name_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "PartnerNameForms", type: :request do
+    include_examples "GET flexible form", "partner_name_form"
+
+    include_examples "POST without params form", "partner_name_form"
+
+    describe "GET back_partner_name_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "partner_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the business_type form" do
+            get back_partner_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_partner_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/partner_overview_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_overview_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "PartnerNameForms", type: :request do
+    include_examples "GET flexible form", "partner_name_form"
+
+    include_examples "POST without params form", "partner_name_form"
+
+    describe "GET back_partner_name_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "partner_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the business_type form" do
+            get back_partner_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_partner_name_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/partner_postcode_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_postcode_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "PartnerPostcodeForms", type: :request do
+    include_examples "GET flexible form", "partner_postcode_form"
+
+    include_examples "POST without params form", "partner_postcode_form"
+
+    describe "GET back_partner_postcode_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "partner_postcode_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the partner_name form" do
+            get back_partner_postcode_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_partner_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_partner_postcode_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/registration_complete_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/registration_complete_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "RegistrationCompleteForms", type: :request do
+    describe "GET new_registration_complete_form_path" do
+      context "when no new registration exists" do
+        it "redirects to the start page" do
+          get new_registration_complete_form_path("wibblewobblejellyonaplate")
+
+          expect(response).to redirect_to(new_start_form_path)
+        end
+      end
+
+      context "when a valid new registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "registration_complete_form")
+        end
+
+        context "when the workflow_state is correct" do
+          it "returns a 200 status and renders the :new template" do
+            get new_registration_complete_form_path(transient_registration[:token])
+
+            expect(response).to have_http_status(200)
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context "when the workflow_state is not correct" do
+          before do
+            transient_registration.update(workflow_state: "company_name_form")
+          end
+
+          it "redirects to the correct page" do
+            get new_registration_complete_form_path(transient_registration[:token])
+
+            expect(response).to redirect_to(new_company_name_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/site_grid_reference_forms_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "SiteGridReferenceForms", type: :request do
+    include_examples "GET flexible form", "site_grid_reference_form"
+
+    include_examples "POST without params form", "site_grid_reference_form"
+
+    describe "GET back_site_grid_reference_forms_path" do
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "site_grid_reference_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the confirm_exemption form" do
+            get back_site_grid_reference_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_confirm_exemption_form_path(transient_registration[:token]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:new_registration,
+                 workflow_state: "declaration_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response and redirects to the correct form for the state" do
+            get back_site_grid_reference_forms_path(transient_registration[:token])
+
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(new_declaration_form_path(transient_registration[:token]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/start_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/start_forms_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe "StartForms", type: :request do
+    describe "GET new_start_form_path" do
+      it "returns a 200 response and render the new template" do
+        get new_start_form_path
+
+        expect(response).to render_template(:new)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe "POST start_form_path" do
+      let(:new_registration) { create(:new_registration, workflow_state: "start_form") }
+
+      context "when a new registration token is not passed to the request" do
+        let(:params) { nil }
+
+        it "creates a NewRegistration, updates the workflow and redirects to exemption_form with a 302 status code" do
+          expect(FloodRiskEngine::NewRegistration.count).to eq(0)
+
+          post new_start_form_path(params)
+
+          new_registration = FloodRiskEngine::NewRegistration.last
+
+          expect(new_registration).to be_present
+          expect(response).to redirect_to(new_exemption_form_path(new_registration.token))
+          expect(response).to have_http_status(302)
+          expect(new_registration.workflow_state).to eq("exemption_form")
+        end
+      end
+
+      context "when a new registration token is passed to the request" do
+        let(:params) { { token: new_registration.token } }
+
+        it "updates the workflow and redirects to exemption_form with a 302 status code" do
+          post new_start_form_path(params)
+
+          new_registration.reload
+
+          expect(response).to redirect_to(new_exemption_form_path(new_registration.token))
+          expect(response).to have_http_status(302)
+          expect(new_registration.workflow_state).to eq("exemption_form")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers/form_request_helpers.rb
+++ b/spec/support/helpers/form_request_helpers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module FormRequestHelpers
+  def post_form_with_params(form, token, params = {})
+    post create_path_for(form, token), params: params_for_form(form, params)
+  end
+
+  # Should call a method like location_forms_path
+  def create_path_for(form, token)
+    public_send("#{form}s_path", token)
+  end
+
+  # Should output a hash like { location_forms: params }
+  def params_for_form(form, params)
+    hash = {}
+    hash[form.to_sym] = params
+    hash
+  end
+end
+
+RSpec.configure do |config|
+  config.include FormRequestHelpers
+end

--- a/spec/support/shared_examples/requests/get_flexible_form.rb
+++ b/spec/support/shared_examples/requests/get_flexible_form.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# A 'flexible' form is a form that we don't mind users getting to via the back button.
+# Getting to this form too early by URL-hacking might cause problems for the user,
+# but we know that we will be validating the entire transient_registration later in the
+# journey, so there is no risk of dodgy data or the user skipping essential steps.
+# If the user loads one of these forms, we change the workflow_state to match their request,
+# so the browser and the database agree about what form the user is currently using.
+RSpec.shared_examples "GET flexible form" do |form|
+  context "when a registration is in progress" do
+    let(:transient_registration) do
+      create(:new_registration,
+             workflow_state: form)
+    end
+
+    context "when the workflow_state matches the request" do
+      it "loads the requested page" do
+        get new_path_for(form, transient_registration)
+        expect(response).to render_template("#{form}s/new")
+      end
+    end
+
+    context "when the workflow_state is a flexible form" do
+      let(:saved_state) do
+        # We need to pick a different but also valid state for the transient_registration
+        # 'contact_name_form' is the default, unless this would actually match!
+        if form == "contact_name_form"
+          "contact_phone_form"
+        else
+          "contact_name_form"
+        end
+      end
+
+      before do
+        transient_registration.update(workflow_state: saved_state)
+      end
+
+      it "updates the workflow_state to match the requested page and loads the requested page" do
+        get new_path_for(form, transient_registration)
+
+        expect(transient_registration.reload[:workflow_state]).to eq(form)
+        expect(response).to render_template("#{form}s/new")
+      end
+    end
+
+    # Once users are in a locked-in workflow state, for example, the end of the journey,
+    # we don't want them to be able to skip back to an earlier page any more.
+    context "when the workflow_state is a locked-in form" do
+      let(:saved_state) do
+        "declaration_form"
+      end
+
+      before do
+        transient_registration.update(workflow_state: saved_state)
+      end
+
+      it "does not change the workflow_state and redirects to the saved workflow_state" do
+        workflow_state = transient_registration[:workflow_state]
+
+        get new_path_for(form, transient_registration)
+
+        expect(transient_registration.reload[:workflow_state]).to eq(saved_state)
+        expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
+      end
+    end
+  end
+
+  # Should call a method like new_location_form_path("tokengoeshere")
+  def new_path_for(form, transient_registration)
+    send("new_#{form}_path", transient_registration.token)
+  end
+end

--- a/spec/support/shared_examples/requests/get_locked_in_form.rb
+++ b/spec/support/shared_examples/requests/get_locked_in_form.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# A 'locked-in' form is a form we definitely don't want users to access out-of-order,
+# for example, by clicking the back button or URL-hacking.
+# Users shouldn't be able to get into locked-in forms this way.
+# They also shouldn't be able to get out of them, except by using buttons within the app.
+# This prevents users from skipping past the declaration stage, or trying to go back and
+# make changes to their information after they've completed a registration.
+RSpec.shared_examples "GET locked-in form" do |form|
+  context "when a registration is in progress" do
+    let(:transient_registration) do
+      create(:new_registration)
+    end
+
+    context "when the workflow_state matches the requested form" do
+      before do
+        transient_registration.update(workflow_state: form)
+      end
+
+      it "loads the form and does not change the workflow_state" do
+        state_before_request = transient_registration[:workflow_state]
+
+        get new_path_for(form, transient_registration)
+
+        expect(response).to have_http_status(200)
+        expect(transient_registration.reload[:workflow_state]).to eq(state_before_request)
+      end
+    end
+
+    context "when the workflow_state is a flexible form" do
+      before do
+        transient_registration.update(workflow_state: "contact_name_form")
+      end
+
+      it "does not change the workflow_state and redirects to the saved workflow_state" do
+        workflow_state = transient_registration[:workflow_state]
+
+        get new_path_for(form, transient_registration)
+
+        expect(transient_registration.reload[:workflow_state]).to eq(workflow_state)
+        expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
+      end
+    end
+
+    context "when the workflow_state is a locked-in form" do
+      before do
+        # We need to pick a different but also valid state for the transient_registration
+        # 'declaration_form' is the default, unless this would actually match!
+        different_state = if form == "declaration_form"
+                            "registration_complete_form"
+                          else
+                            "declaration_form"
+                          end
+        transient_registration.update(workflow_state: different_state)
+      end
+
+      it "does not change the workflow_state and redirects to the saved workflow_state" do
+        workflow_state = transient_registration[:workflow_state]
+
+        get new_path_for(form, transient_registration)
+
+        expect(transient_registration.reload[:workflow_state]).to eq(workflow_state)
+        expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
+      end
+    end
+  end
+
+  # Should call a method like new_location_form_path("CBDU1234")
+  def new_path_for(form, transient_registration)
+    public_send("new_#{form}_path", transient_registration.token)
+  end
+end

--- a/spec/support/shared_examples/requests/post_without_params_form.rb
+++ b/spec/support/shared_examples/requests/post_without_params_form.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# When a user submits a form, that form must match the expected workflow_state.
+# We don't adjust the state to match what the user is doing like we do for viewing forms.
+
+# We expect to receive the name of the form (for example, location_form),
+# a set of valid params, a set of invalid params, and an attribute to test persistence
+# Default to :reg_identifier for forms which don't submit new data
+RSpec.shared_examples "POST without params form" do |form|
+  context "when the token is invalid" do
+    it "redirects to the start page" do
+      post_form_with_params(form, "foo")
+
+      expect(response).to redirect_to(new_start_form_path)
+    end
+  end
+
+  context "when a registration is in progress" do
+    let(:transient_registration) do
+      create(:new_registration)
+    end
+
+    context "when the workflow_state matches the requested form" do
+      before do
+        transient_registration.update(workflow_state: form)
+      end
+
+      context "when the params are valid" do
+        it "changes the workflow_state and returns a 302 response" do
+          state_before_request = transient_registration[:workflow_state]
+          post_form_with_params(form, transient_registration.token)
+
+          expect(transient_registration.reload[:workflow_state]).to_not eq(state_before_request)
+          expect(response).to have_http_status(302)
+        end
+      end
+    end
+
+    context "when the workflow_state does not match the requested form" do
+      before do
+        # We need to pick a different but also valid state for the transient_registration
+        # 'confirm_exemption_form' is the default, unless this would actually match!
+        different_state = if form == "confirm_exemption_form"
+                            "check_your_answers_form"
+                          else
+                            "confirm_exemption_form"
+                          end
+        transient_registration.update(workflow_state: different_state)
+      end
+
+      it "does not update the transient_registration or workflow_state, and redirects to the workflow_state" do
+        transient_reg_before_submitting = transient_registration
+        workflow_state = transient_registration[:workflow_state]
+
+        post_form_with_params(form, transient_registration.token)
+
+        expect(transient_registration.reload).to eq(transient_reg_before_submitting)
+        expect(response).to redirect_to(new_path_for(workflow_state, transient_registration))
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1472

This PR sets up new controllers and routes for the updated new registration workflow. These will follow the format we already use in WCR and WEX.

The end result should be an empty 'happy path' journey that a user can click through and see the pages in the expected journey. The actual content of the pages won't be merged in yet.