### PR TITLE
Remove erroneous `pages` route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,7 +234,4 @@ FloodRiskEngine::Engine.routes.draw do
 
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
-
-  # Static pages with HighVoltage
-  resources :pages, only: [:show], controller: "pages"
 end


### PR DESCRIPTION
- A `pages` route is declared earlier in the file and points to the
`enrollments/pages` controller

- Here we remove the additional `pages` route as it points to the
wrong controller