### PR TITLE
Rename old BaseForm

### DIFF
--- a/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
+++ b/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class AddExemptionsForm < BaseForm
+    class AddExemptionsForm < BaseStepsForm
       property :exemption_ids
 
       attr_reader :all_exemptions

--- a/app/forms/flood_risk_engine/steps/base_address_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class BaseAddressForm < BaseForm
+    class BaseAddressForm < BaseStepsForm
 
       property :uprn
       property :temp_addresses, virtual: true

--- a/app/forms/flood_risk_engine/steps/base_redirectable_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_redirectable_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class BaseRedirectableForm < BaseForm
+    class BaseRedirectableForm < BaseStepsForm
 
       attr_accessor :redirection_url
       attr_accessor :redirect

--- a/app/forms/flood_risk_engine/steps/base_steps_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_steps_form.rb
@@ -3,14 +3,14 @@ require_dependency "reform"
 # Common step form functionality.
 module FloodRiskEngine
   module Steps
-    class BaseForm < Reform::Form
+    class BaseStepsForm < Reform::Form
       include ActionView::Helpers::TranslationHelper
       include ActiveModel::Validations
 
       feature Reform::Form::ActiveModel::Validations
 
-      include BaseFormCommon
-      extend BaseFormCommon
+      include BaseStepsFormCommon
+      extend BaseStepsFormCommon
       def self.factory(enrollment, factory_type: :default)
         case factory_type
         when :correspondence_contact

--- a/app/forms/flood_risk_engine/steps/base_steps_form_common.rb
+++ b/app/forms/flood_risk_engine/steps/base_steps_form_common.rb
@@ -1,7 +1,7 @@
-# Common step form functionality that can be mixed into all Forms via BaseForm.
+# Common step form functionality that can be mixed into all Forms via BaseStepsForm.
 module FloodRiskEngine
   module Steps
-    module BaseFormCommon
+    module BaseStepsFormCommon
 
       # rubocop:disable Style/ExtendSelf
       # rubocop:disable Style/ModuleFunction:

--- a/app/forms/flood_risk_engine/steps/check_your_answers_form.rb
+++ b/app/forms/flood_risk_engine/steps/check_your_answers_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class CheckYourAnswersForm < BaseForm
+    class CheckYourAnswersForm < BaseStepsForm
       delegate :rows, to: :review_presenter
 
       def params_key

--- a/app/forms/flood_risk_engine/steps/confirmation_form.rb
+++ b/app/forms/flood_risk_engine/steps/confirmation_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class ConfirmationForm < BaseForm
+    class ConfirmationForm < BaseStepsForm
 
       def self.params_key
         :confirmation

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -3,7 +3,7 @@ require "active_model/validations/confirmation"
 
 module FloodRiskEngine
   module Steps
-    class CorrespondenceContactEmailForm < BaseForm
+    class CorrespondenceContactEmailForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :correspondence_contact

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_name_form.rb
@@ -5,7 +5,7 @@
 #
 module FloodRiskEngine
   module Steps
-    class CorrespondenceContactNameForm < FloodRiskEngine::Steps::BaseForm
+    class CorrespondenceContactNameForm < FloodRiskEngine::Steps::BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :correspondence_contact

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_telephone_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_telephone_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class CorrespondenceContactTelephoneForm < BaseForm
+    class CorrespondenceContactTelephoneForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :correspondence_contact

--- a/app/forms/flood_risk_engine/steps/declaration_form.rb
+++ b/app/forms/flood_risk_engine/steps/declaration_form.rb
@@ -1,7 +1,7 @@
 # Use this form object for steps with no html form
 module FloodRiskEngine
   module Steps
-    class DeclarationForm < BaseForm
+    class DeclarationForm < BaseStepsForm
       def save
         true
       end

--- a/app/forms/flood_risk_engine/steps/email_someone_else_form.rb
+++ b/app/forms/flood_risk_engine/steps/email_someone_else_form.rb
@@ -3,7 +3,7 @@ require "active_model/validations/confirmation"
 
 module FloodRiskEngine
   module Steps
-    class EmailSomeoneElseForm < BaseForm
+    class EmailSomeoneElseForm < BaseStepsForm
 
       def self.factory(enrollment)
         enrollment.secondary_contact ||= Contact.new

--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -1,7 +1,7 @@
 require_relative "../../../validators/flood_risk_engine/grid_reference_validator"
 module FloodRiskEngine
   module Steps
-    class GridReferenceForm < BaseForm
+    class GridReferenceForm < BaseStepsForm
 
       def self.factory(enrollment)
         enrollment.exemption_location ||= Location.new

--- a/app/forms/flood_risk_engine/steps/individual_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/individual_name_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class IndividualNameForm < BaseForm
+    class IndividualNameForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/limited_company_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_name_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LimitedCompanyNameForm < FloodRiskEngine::Steps::BaseForm
+    class LimitedCompanyNameForm < FloodRiskEngine::Steps::BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/limited_company_number_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_number_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LimitedCompanyNumberForm < FloodRiskEngine::Steps::BaseForm
+    class LimitedCompanyNumberForm < FloodRiskEngine::Steps::BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/limited_liability_partnership_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_liability_partnership_name_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LimitedLiabilityPartnershipNameForm < BaseForm
+    class LimitedLiabilityPartnershipNameForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/limited_liability_partnership_number_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_liability_partnership_number_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LimitedLiabilityPartnershipNumberForm < BaseForm
+    class LimitedLiabilityPartnershipNumberForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/local_authority_form.rb
+++ b/app/forms/flood_risk_engine/steps/local_authority_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LocalAuthorityForm < BaseForm
+    class LocalAuthorityForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/null_form.rb
+++ b/app/forms/flood_risk_engine/steps/null_form.rb
@@ -1,7 +1,7 @@
 # Use this form object for steps with no html form
 module FloodRiskEngine
   module Steps
-    class NullForm < BaseForm
+    class NullForm < BaseStepsForm
       def save
         true
       end

--- a/app/forms/flood_risk_engine/steps/other_form.rb
+++ b/app/forms/flood_risk_engine/steps/other_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class OtherForm < BaseForm
+    class OtherForm < BaseStepsForm
 
       def self.factory(enrollment)
         super enrollment, factory_type: :organisation

--- a/app/forms/flood_risk_engine/steps/partnership_detail_form.rb
+++ b/app/forms/flood_risk_engine/steps/partnership_detail_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class PartnershipDetailForm < BaseForm
+    class PartnershipDetailForm < BaseStepsForm
       def initialize(enrollment)
         @enrollment = enrollment
         remove_incomplete_partners

--- a/app/forms/flood_risk_engine/steps/partnership_form.rb
+++ b/app/forms/flood_risk_engine/steps/partnership_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class PartnershipForm < BaseForm
+    class PartnershipForm < BaseStepsForm
       def self.factory(enrollment)
         contact = Contact.new
         new(contact, enrollment)

--- a/app/forms/flood_risk_engine/steps/unknown_form.rb
+++ b/app/forms/flood_risk_engine/steps/unknown_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class UnknownForm < BaseForm
+    class UnknownForm < BaseStepsForm
       def self.params_key
         :unknown
       end

--- a/app/forms/flood_risk_engine/steps/user_type_form.rb
+++ b/app/forms/flood_risk_engine/steps/user_type_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class UserTypeForm < BaseForm
+    class UserTypeForm < BaseStepsForm
       def self.params_key
         :user_type
       end

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_update_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_update_spec.rb
@@ -12,7 +12,7 @@ module FloodRiskEngine
 
       before do
         set_journey_token
-        expect_any_instance_of(Steps::BaseForm).to(
+        expect_any_instance_of(Steps::BaseStepsForm).to(
           receive(:validate).and_return(validation_result)
         )
         put :update, params: { id: step, enrollment_id: enrollment }

--- a/spec/lib/flood_risk_engine/form_object_factory_spec.rb
+++ b/spec/lib/flood_risk_engine/form_object_factory_spec.rb
@@ -15,11 +15,11 @@ module FloodRiskEngine
     end
 
     it "returns a form Object for a valid step", duff: true do
-      expect(factory.form_object_for(Enrollment.new.current_step.to_sym, enrollment)).to be_a Steps::BaseForm
+      expect(factory.form_object_for(Enrollment.new.current_step.to_sym, enrollment)).to be_a Steps::BaseStepsForm
     end
 
     it "returns a form Object for a valid step" do
-      expect(factory.form_object_for(Enrollment.new.current_step.to_s, enrollment)).to be_a Steps::BaseForm
+      expect(factory.form_object_for(Enrollment.new.current_step.to_s, enrollment)).to be_a Steps::BaseStepsForm
     end
   end
 end


### PR DESCRIPTION
This was causing a clash when eagerloading was switched on as we had multiple BaseForms.