### PR TITLE
Add validation and params to new workflow forms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       defra_ruby_alert (~> 2.1.1)
       defra_ruby_area (~> 2.0)
       defra_ruby_email (~> 1.1)
+      defra_ruby_validators
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       finite_machine (~> 0.11.3)
@@ -170,6 +171,12 @@ GEM
       notifications-ruby-client
       rails (~> 6.0.3.1)
       sprockets (~> 3.7.2)
+    defra_ruby_validators (2.4.1)
+      activemodel
+      os_map_ref
+      phonelib
+      rest-client (~> 2.0)
+      validates_email_format_of
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     dibber (0.6.0)

--- a/app/controllers/flood_risk_engine/additional_contact_email_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/additional_contact_email_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(AdditionalContactEmailForm, "additional_contact_email_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:additional_contact_email_form, {}).permit(:additional_contact_email, :confirmed_email)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/business_type_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/business_type_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(BusinessTypeForm, "business_type_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:business_type_form, {}).permit(:business_type)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/company_name_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_name_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(CompanyNameForm, "company_name_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:company_name_form, {}).permit(:company_name)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/company_number_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_number_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(CompanyNumberForm, "company_number_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:company_number_form, {}).permit(:company_number)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/company_postcode_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/company_postcode_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(CompanyPostcodeForm, "company_postcode_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:company_postcode_form, {}).permit(:temp_company_postcode)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/contact_email_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_email_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(ContactEmailForm, "contact_email_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:contact_email_form, {}).permit(:contact_email, :confirmed_email)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/contact_name_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_name_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(ContactNameForm, "contact_name_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:contact_name_form, {}).permit(:contact_name, :contact_position)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/contact_phone_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/contact_phone_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(ContactPhoneForm, "contact_phone_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:contact_phone_form, {}).permit(:contact_phone)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/declaration_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/declaration_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(DeclarationForm, "declaration_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:declaration_form, {}).permit(:declaration)
+    end
   end
 end

--- a/app/controllers/flood_risk_engine/exemption_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/exemption_forms_controller.rb
@@ -9,5 +9,11 @@ module FloodRiskEngine
     def create
       super(ExemptionForm, "exemption_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:exemption_form, {}).permit(exemption_ids: [])
+    end
   end
 end

--- a/app/forms/concerns/flood_risk_engine/can_set_custom_error_message.rb
+++ b/app/forms/concerns/flood_risk_engine/can_set_custom_error_message.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CanSetCustomErrorMessage
+    extend ActiveSupport::Concern
+
+    included do
+      def self.custom_error_messages(attribute, *errors)
+        messages = {}
+
+        errors.each do |error|
+          messages[error] = I18n.t("activemodel.errors.models."\
+                                       "flood_risk_engine/#{form_name}"\
+                                       ".attributes.#{attribute}.#{error}")
+        end
+
+        messages
+      end
+
+      def self.form_name
+        name.split("::").last.underscore
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/additional_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/additional_contact_email_form.rb
@@ -2,11 +2,28 @@
 
 module FloodRiskEngine
   class AdditionalContactEmailForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :additional_contact_email, to: :transient_registration
+    attr_accessor :confirmed_email
 
-      super(attributes)
+    validates :additional_contact_email, "defra_ruby/validators/email": true
+    validates :confirmed_email, "defra_ruby/validators/email": {
+      messages: custom_error_messages(:confirmed_email, :blank, :invalid_format)
+    }
+    validates :confirmed_email, "flood_risk_engine/matching_email": { compare_to: :additional_contact_email }
+
+    after_initialize :populate_confirmed_email
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.confirmed_email = params[:confirmed_email]
+
+      super(params.permit(:additional_contact_email))
+    end
+
+    private
+
+    def populate_confirmed_email
+      self.confirmed_email = additional_contact_email
     end
   end
 end

--- a/app/forms/flood_risk_engine/base_form.rb
+++ b/app/forms/flood_risk_engine/base_form.rb
@@ -4,6 +4,7 @@ module FloodRiskEngine
   class BaseForm
     include ActiveModel::Model
     include CanStripWhitespace
+    include CanSetCustomErrorMessage
 
     extend ActiveModel::Callbacks
 

--- a/app/forms/flood_risk_engine/business_type_form.rb
+++ b/app/forms/flood_risk_engine/business_type_form.rb
@@ -2,11 +2,8 @@
 
 module FloodRiskEngine
   class BusinessTypeForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :business_type, to: :transient_registration
 
-      super(attributes)
-    end
+    validates :business_type, "defra_ruby/validators/business_type": true
   end
 end

--- a/app/forms/flood_risk_engine/company_name_form.rb
+++ b/app/forms/flood_risk_engine/company_name_form.rb
@@ -2,11 +2,8 @@
 
 module FloodRiskEngine
   class CompanyNameForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :company_name, to: :transient_registration
 
-      super(attributes)
-    end
+    validates :company_name, "flood_risk_engine/company_name": true
   end
 end

--- a/app/forms/flood_risk_engine/company_number_form.rb
+++ b/app/forms/flood_risk_engine/company_number_form.rb
@@ -2,11 +2,27 @@
 
 module FloodRiskEngine
   class CompanyNumberForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :company_number, to: :transient_registration
 
-      super(attributes)
+    validates :company_number, "flood_risk_engine/company_number": true
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      # If param isn't set, use a blank string instead to avoid errors with the validator
+      params[:company_number] = process_company_number(params[:company_number])
+
+      super
+    end
+
+    private
+
+    def process_company_number(company_number)
+      return unless company_number.present?
+
+      number = company_number.to_s
+      # Should be 8 characters, so if it's not, add 0s to the start
+      number = "0#{number}" while number.length < 8
+      number
     end
   end
 end

--- a/app/forms/flood_risk_engine/company_postcode_form.rb
+++ b/app/forms/flood_risk_engine/company_postcode_form.rb
@@ -1,12 +1,31 @@
 # frozen_string_literal: true
 
 module FloodRiskEngine
-  class CompanyPostcodeForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+  class CompanyPostcodeForm < BaseForm
+    delegate :temp_company_postcode, to: :transient_registration
 
-      super(attributes)
+    validates :temp_company_postcode, "flood_risk_engine/postcode": true
+
+    def submit(params)
+      params[:temp_company_postcode] = format_postcode(params[:temp_company_postcode])
+
+      # We persist the postcode regardless of validations.
+      transient_registration.update(params)
+
+      super({})
+    end
+
+    def address_finder_errored!
+      # Used in the postcode validator to set the parameter.
+      # This is then saved in the `#submit` and used by AASM to decide
+      # what is the next valid status for the user.
+      transient_registration.address_finder_error = true
+    end
+
+    private
+
+    def format_postcode(postcode)
+      postcode&.upcase&.strip
     end
   end
 end

--- a/app/forms/flood_risk_engine/contact_email_form.rb
+++ b/app/forms/flood_risk_engine/contact_email_form.rb
@@ -2,11 +2,28 @@
 
 module FloodRiskEngine
   class ContactEmailForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :contact_email, to: :transient_registration
+    attr_accessor :confirmed_email
 
-      super(attributes)
+    validates :contact_email, "defra_ruby/validators/email": true
+    validates :confirmed_email, "defra_ruby/validators/email": {
+      messages: custom_error_messages(:confirmed_email, :blank, :invalid_format)
+    }
+    validates :confirmed_email, "flood_risk_engine/matching_email": { compare_to: :contact_email }
+
+    after_initialize :populate_confirmed_email
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.confirmed_email = params[:confirmed_email]
+
+      super(params.permit(:contact_email))
+    end
+
+    private
+
+    def populate_confirmed_email
+      self.confirmed_email = contact_email
     end
   end
 end

--- a/app/forms/flood_risk_engine/contact_name_form.rb
+++ b/app/forms/flood_risk_engine/contact_name_form.rb
@@ -2,11 +2,10 @@
 
 module FloodRiskEngine
   class ContactNameForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :contact_name, to: :transient_registration
+    delegate :contact_position, to: :transient_registration
 
-      super(attributes)
-    end
+    validates :contact_name, "flood_risk_engine/contact_name": true
+    validates :contact_position, "defra_ruby/validators/position": true
   end
 end

--- a/app/forms/flood_risk_engine/contact_phone_form.rb
+++ b/app/forms/flood_risk_engine/contact_phone_form.rb
@@ -2,11 +2,8 @@
 
 module FloodRiskEngine
   class ContactPhoneForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :contact_phone, to: :transient_registration
 
-      super(attributes)
-    end
+    validates :contact_phone, "defra_ruby/validators/phone_number": true
   end
 end

--- a/app/forms/flood_risk_engine/declaration_form.rb
+++ b/app/forms/flood_risk_engine/declaration_form.rb
@@ -2,15 +2,12 @@
 
 module FloodRiskEngine
   class DeclarationForm < ::FloodRiskEngine::BaseForm
+    delegate :declaration, to: :transient_registration
+
+    validates :declaration, inclusion: { in: [true] }
+
     def self.can_navigate_flexibly?
       false
-    end
-
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
-
-      super(attributes)
     end
   end
 end

--- a/app/forms/flood_risk_engine/exemption_form.rb
+++ b/app/forms/flood_risk_engine/exemption_form.rb
@@ -2,11 +2,8 @@
 
 module FloodRiskEngine
   class ExemptionForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :exemptions, to: :transient_registration
 
-      super(attributes)
-    end
+    validates :exemptions, "flood_risk_engine/exemptions": true
   end
 end

--- a/app/forms/flood_risk_engine/steps/base_address_search_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_search_form.rb
@@ -5,7 +5,7 @@ module FloodRiskEngine
 
       validates :postcode, presence: { message: I18n.t("flood_risk_engine.validation_errors.postcode.blank") }
 
-      validates :postcode, 'flood_risk_engine/postcode': true, allow_blank: true
+      validates :postcode, 'flood_risk_engine/legacy_postcode': true, allow_blank: true
 
       def validate(params)
         valid = super(params)

--- a/app/models/flood_risk_engine/transient_address.rb
+++ b/app/models/flood_risk_engine/transient_address.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class TransientAddress < ApplicationRecord
+    self.table_name = "transient_addresses"
+
+    belongs_to :transient_addressable, polymorphic: true
+
+    enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
+    enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
+  end
+end

--- a/app/models/flood_risk_engine/transient_person.rb
+++ b/app/models/flood_risk_engine/transient_person.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class TransientPerson < ApplicationRecord
+    self.table_name = "transient_people"
+
+    belongs_to :transient_registration
+    has_one :transient_addresses, as: :transient_addressable
+  end
+end

--- a/app/models/flood_risk_engine/transient_registration.rb
+++ b/app/models/flood_risk_engine/transient_registration.rb
@@ -8,8 +8,8 @@ module FloodRiskEngine
 
     has_many :transient_addresses, as: :transient_addressable
     has_many :transient_people
-    has_one :transient_registration_exemption, dependent: :destroy
-    has_one :exemption, through: :transient_registration_exemptions
+    has_many :transient_registration_exemptions, dependent: :destroy
+    has_many :exemptions, through: :transient_registration_exemptions
 
     # HasSecureToken provides an easy way to generate unique random tokens for
     # any model in ruby on rails. We use it to uniquely identify an registration

--- a/app/models/flood_risk_engine/transient_registration.rb
+++ b/app/models/flood_risk_engine/transient_registration.rb
@@ -6,6 +6,11 @@ module FloodRiskEngine
 
     self.table_name = "transient_registrations"
 
+    has_many :transient_addresses, as: :transient_addressable
+    has_many :transient_people
+    has_one :transient_registration_exemption, dependent: :destroy
+    has_one :exemption, through: :transient_registration_exemptions
+
     # HasSecureToken provides an easy way to generate unique random tokens for
     # any model in ruby on rails. We use it to uniquely identify an registration
     # by something other than it's db ID, or its reference number. We can then

--- a/app/models/flood_risk_engine/transient_registration_exemption.rb
+++ b/app/models/flood_risk_engine/transient_registration_exemption.rb
@@ -5,6 +5,6 @@ module FloodRiskEngine
     self.table_name = "transient_registration_exemptions"
 
     belongs_to :transient_registration
-    belongs_to :exemption
+    belongs_to :exemption, foreign_key: "flood_risk_engine_exemption_id"
   end
 end

--- a/app/models/flood_risk_engine/transient_registration_exemption.rb
+++ b/app/models/flood_risk_engine/transient_registration_exemption.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class TransientRegistrationExemption < ApplicationRecord
+    self.table_name = "transient_registration_exemptions"
+
+    belongs_to :transient_registration
+    belongs_to :exemption
+  end
+end

--- a/app/validators/concerns/flood_risk_engine/can_add_validation_errors.rb
+++ b/app/validators/concerns/flood_risk_engine/can_add_validation_errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CanAddValidationErrors
+    private
+
+    def add_validation_error(record, attribute, error)
+      record.errors.add(attribute,
+                        error,
+                        message: error_message(record, attribute, error))
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/validators/concerns/flood_risk_engine/can_validate_length.rb
+++ b/app/validators/concerns/flood_risk_engine/can_validate_length.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CanValidateLength
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def value_is_not_too_long?(record, attribute, value, max_length)
+        return true if value.length <= max_length
+
+        add_validation_error(record, attribute, :too_long)
+        false
+      end
+    end
+  end
+end

--- a/app/validators/concerns/flood_risk_engine/can_validate_presence.rb
+++ b/app/validators/concerns/flood_risk_engine/can_validate_presence.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  module CanValidatePresence
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def value_is_present?(record, attribute, value)
+        return true if value.present?
+
+        add_validation_error(record, attribute, :blank)
+        false
+      end
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/company_name_validator.rb
+++ b/app/validators/flood_risk_engine/company_name_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNameValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+    include CanValidatePresence
+    include CanValidateLength
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+
+      max_length = 255
+      value_is_not_too_long?(record, attribute, value, max_length)
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/company_number_validator.rb
+++ b/app/validators/flood_risk_engine/company_number_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class CompanyNumberValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+    include CanValidatePresence
+
+    # Examples we need to validate are
+    # 10997904, 09764739
+    # SC534714, CE000958
+    # IP00141R, IP27702R, SP02252R
+    # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/426891/uniformResourceIdentifiersCustomerGuide.pdf
+    VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX = Regexp.new(
+      /\A(\d{8,8}$)|([a-zA-Z]{2}\d{6}$)|([a-zA-Z]{2}\d{5}[a-zA-Z]{1}$)\z/i
+    ).freeze
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+
+      format_is_valid?(record, attribute, value)
+    end
+
+    private
+
+    def format_is_valid?(record, attribute, value)
+      return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
+
+      add_validation_error(record, attribute, :invalid_format)
+      false
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/contact_name_validator.rb
+++ b/app/validators/flood_risk_engine/contact_name_validator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ContactNameValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+    include CanValidatePresence
+    include CanValidateLength
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+      return false unless value_has_no_invalid_characters?(record, attribute, value)
+
+      max_length = 70
+      value_is_not_too_long?(record, attribute, value, max_length)
+    end
+
+    private
+
+    def value_has_no_invalid_characters?(record, attribute, value)
+      # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
+      return true if value.match?(/\A[-a-z\s,.']+\z/i)
+
+      add_validation_error(record, attribute, :invalid)
+      false
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/exemptions_validator.rb
+++ b/app/validators/flood_risk_engine/exemptions_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class ExemptionsValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
+    def validate_each(record, attribute, value)
+      return true if valid_exemption?(value)
+
+      add_validation_error(record, attribute, :inclusion)
+      false
+    end
+
+    private
+
+    def valid_exemption?(value)
+      Exemption.where(id: value).any?
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/legacy_postcode_validator.rb
+++ b/app/validators/flood_risk_engine/legacy_postcode_validator.rb
@@ -1,0 +1,15 @@
+# Validates the Format of a Postode
+#  Uses external gem : https://github.com/threedaymonk/uk_postcode
+#
+require "uk_postcode"
+
+module FloodRiskEngine
+  class LegacyPostcodeValidator < ActiveModel::EachValidator
+
+    def validate_each(record, attribute, value)
+      return if UKPostcode.parse(value).full_valid?
+      record.errors.add attribute, I18n.t("flood_risk_engine.validation_errors.postcode.enter_a_valid_postcode")
+    end
+
+  end
+end

--- a/app/validators/flood_risk_engine/matching_email_validator.rb
+++ b/app/validators/flood_risk_engine/matching_email_validator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class MatchingEmailValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
+    # Expects to be passed an attribute on the same record to confirm against,
+    # for example: validates :confirmed_email, matching_email: { compare_to: :contact_email }
+    def validate_each(record, attribute, value)
+      email_address_to_confirm = record.send(options[:compare_to])
+      return true if value == email_address_to_confirm || value.blank?
+
+      add_validation_error(record, attribute, :does_not_match)
+      false
+    end
+  end
+end

--- a/app/validators/flood_risk_engine/postcode_validator.rb
+++ b/app/validators/flood_risk_engine/postcode_validator.rb
@@ -1,15 +1,46 @@
-# Validates the Format of a Postode
-#  Uses external gem : https://github.com/threedaymonk/uk_postcode
-#
+# frozen_string_literal: true
+
 require "uk_postcode"
 
 module FloodRiskEngine
   class PostcodeValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
 
     def validate_each(record, attribute, value)
-      return if UKPostcode.parse(value).full_valid?
-      record.errors.add attribute, I18n.t("flood_risk_engine.validation_errors.postcode.enter_a_valid_postcode")
+      return unless value_is_present?(record, attribute, value)
+      return unless value_uses_correct_format?(record, attribute, value)
+
+      postcode_returns_results?(record, attribute, value)
     end
 
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      add_validation_error(record, attribute, :blank)
+      false
+    end
+
+    def value_uses_correct_format?(record, attribute, value)
+      return true if UKPostcode.parse(value).full_valid?
+
+      add_validation_error(record, attribute, :wrong_format)
+      false
+    end
+
+    def postcode_returns_results?(record, attribute, value)
+      response = AddressLookupService.run(value)
+
+      return true if response.successful?
+
+      if response.error.is_a?(DefraRuby::Address::NoMatchError)
+        add_validation_error(record, attribute, :no_results)
+        false
+      else
+        record.address_finder_errored!
+        true
+      end
+    end
   end
 end

--- a/db/migrate/20210628173318_add_fields_to_transient_registration.rb
+++ b/db/migrate/20210628173318_add_fields_to_transient_registration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddFieldsToTransientRegistration < ActiveRecord::Migration[6.0]
+  def change
+    change_table :transient_registrations do |t|
+      t.string :additional_contact_email
+      t.string :business_type
+      t.string :company_name
+      t.string :company_number
+      t.string :contact_email
+      t.string :contact_name
+      t.string :contact_phone
+      t.string :contact_position
+      t.boolean :declaration
+      t.string :temp_company_postcode
+      t.string :temp_grid_reference
+      t.text :temp_site_description
+      t.boolean :address_finder_error, default: false
+    end
+  end
+end

--- a/db/migrate/20210629070929_create_transient_addresses.rb
+++ b/db/migrate/20210629070929_create_transient_addresses.rb
@@ -20,6 +20,9 @@ class CreateTransientAddresses < ActiveRecord::Migration[6.0]
       t.string :addressable_type
       t.string :uprn
       t.string :token
+
+      t.index :addressable_id, unique: true
+      t.index :addressable_type, unique: true
     end
   end
 end

--- a/db/migrate/20210629070929_create_transient_addresses.rb
+++ b/db/migrate/20210629070929_create_transient_addresses.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateTransientAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transient_addresses do |t|
+      t.string :premises, limit: 200
+      t.string :street_address, limit: 160
+      t.string :locality, limit: 70
+      t.string :city, limit: 30
+      t.string :postcode, limit: 8
+      t.integer :county_province_id
+      t.string :country_iso, limit: 3
+      t.integer :address_type, default: 0, null: false
+      t.string :organisation, limit: 255, default: ""
+      t.date :state_date
+      t.string :blpu_state_code
+      t.string :postal_address_code
+      t.string :logical_status_code
+      t.integer :addressable_id
+      t.string :addressable_type
+      t.string :uprn
+      t.string :token
+    end
+  end
+end

--- a/db/migrate/20210629071403_create_transient_people.rb
+++ b/db/migrate/20210629071403_create_transient_people.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateTransientPeople < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transient_people do |t|
+      t.string :first_name
+      t.string :last_name
+      t.belongs_to :transient_registration, index: true, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210629072138_create_transient_registration_exemptions.rb
+++ b/db/migrate/20210629072138_create_transient_registration_exemptions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateTransientRegistrationExemptions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transient_registration_exemptions do |t|
+      t.string :state
+      t.date :registered_on
+      t.date :expires_on
+      t.belongs_to :transient_registration, index: { name: "transient_registration_id" }
+      t.belongs_to :flood_risk_engine_exemption, index: { name: "exemption_id" }
+    end
+  end
+end

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   # Used as part of testing. When enabled adds a /email/last-email route from
   # which details of the last email sent by the app can be accessed
   s.add_dependency "defra_ruby_email", "~> 1.1"
+  s.add_dependency "defra_ruby_validators"
   s.add_dependency "finite_machine", "~> 0.11.3"
   # Enables url obfuscation with 24bit base58 token
   s.add_dependency "has_secure_token", "~> 1.0.0"

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -6,6 +6,7 @@ require "activerecord/session_store"
 require "high_voltage"
 require "defra_ruby/area"
 require "defra_ruby_email"
+require "defra_ruby/validators"
 require "active_support/dependencies"
 require_dependency "virtus"
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,25 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_113422) do
+ActiveRecord::Schema.define(version: 2021_06_29_072138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "enrollment_exports", id: :serial, force: :cascade do |t|
-    t.date "from_date", null: false
-    t.date "to_date", null: false
-    t.string "created_by", null: false
-    t.string "file_name", null: false
-    t.integer "state", default: 0, null: false
-    t.text "failure_text"
-    t.integer "record_count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "date_field_scope", default: 0
-    t.index ["created_at"], name: "index_enrollment_exports_on_created_at"
-    t.index ["file_name"], name: "index_enrollment_exports_on_file_name", unique: true
-  end
 
   create_table "flood_risk_engine_address_searches", id: :serial, force: :cascade do |t|
     t.integer "enrollment_id", null: false
@@ -120,11 +105,8 @@ ActiveRecord::Schema.define(version: 2021_06_24_113422) do
     t.datetime "valid_from"
     t.boolean "asset_found", default: false
     t.boolean "salmonid_river_found", default: false
-    t.integer "accept_reject_decision_user_id"
-    t.datetime "accept_reject_decision_at"
     t.integer "deregister_reason"
     t.integer "assistance_mode", default: 0
-    t.index ["accept_reject_decision_user_id"], name: "by_change_user"
     t.index ["deregister_reason"], name: "by_deregister_reason"
     t.index ["enrollment_id", "exemption_id"], name: "fre_enrollments_exemptions_enrollment_id_exemption_id", unique: true
   end
@@ -199,16 +181,6 @@ ActiveRecord::Schema.define(version: 2021_06_24_113422) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "roles", id: :serial, force: :cascade do |t|
-    t.string "name"
-    t.string "resource_type"
-    t.integer "resource_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
-    t.index ["name"], name: "index_roles_on_name"
-  end
-
   create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
@@ -218,76 +190,61 @@ ActiveRecord::Schema.define(version: 2021_06_24_113422) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
+  create_table "transient_addresses", force: :cascade do |t|
+    t.string "premises", limit: 200
+    t.string "street_address", limit: 160
+    t.string "locality", limit: 70
+    t.string "city", limit: 30
+    t.string "postcode", limit: 8
+    t.integer "county_province_id"
+    t.string "country_iso", limit: 3
+    t.integer "address_type", default: 0, null: false
+    t.string "organisation", limit: 255, default: ""
+    t.date "state_date"
+    t.string "blpu_state_code"
+    t.string "postal_address_code"
+    t.string "logical_status_code"
+    t.integer "addressable_id"
+    t.string "addressable_type"
+    t.string "uprn"
+    t.string "token"
+  end
+
+  create_table "transient_people", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.bigint "transient_registration_id"
+    t.index ["transient_registration_id"], name: "index_transient_people_on_transient_registration_id"
+  end
+
+  create_table "transient_registration_exemptions", force: :cascade do |t|
+    t.string "state"
+    t.date "registered_on"
+    t.date "expires_on"
+    t.bigint "transient_registration_id"
+    t.bigint "flood_risk_engine_exemption_id"
+    t.index ["flood_risk_engine_exemption_id"], name: "exemption_id"
+    t.index ["transient_registration_id"], name: "transient_registration_id"
+  end
+
   create_table "transient_registrations", force: :cascade do |t|
     t.string "token"
     t.string "workflow_state"
     t.string "type", default: "FloodRiskEngine::NewRegistration", null: false
+    t.string "additional_contact_email"
+    t.string "business_type"
+    t.string "company_name"
+    t.string "company_number"
+    t.string "contact_email"
+    t.string "contact_name"
+    t.string "contact_phone"
+    t.string "contact_position"
+    t.boolean "declaration"
+    t.string "temp_company_postcode"
+    t.string "temp_grid_reference"
+    t.text "temp_site_description"
+    t.boolean "address_finder_error", default: false
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
-  end
-
-  create_table "users", id: :serial, force: :cascade do |t|
-    t.string "email", limit: 255, default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.string "invited_by_type"
-    t.integer "invited_by_id"
-    t.integer "invitations_count", default: 0
-    t.integer "failed_attempts", default: 0, null: false
-    t.string "unlock_token"
-    t.text "disabled_comment"
-    t.datetime "disabled_at"
-    t.datetime "locked_at"
-    t.string "role_names"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "unique_session_id", limit: 20
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
-    t.index ["invitations_count"], name: "index_users_on_invitations_count"
-    t.index ["invited_by_id", "invited_by_type"], name: "index_users_on_invited_by_id_and_invited_by_type"
-    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  end
-
-  create_table "users_roles", id: false, force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "role_id"
-    t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
-  end
-
-  create_table "version_associations", id: :serial, force: :cascade do |t|
-    t.integer "version_id"
-    t.string "foreign_key_name", null: false
-    t.integer "foreign_key_id"
-    t.index ["foreign_key_name", "foreign_key_id"], name: "index_version_associations_on_foreign_key"
-    t.index ["version_id"], name: "index_version_associations_on_version_id"
-  end
-
-  create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
-    t.integer "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
-    t.datetime "created_at"
-    t.string "status"
-    t.string "whodunnit_email"
-    t.string "ip"
-    t.string "user_agent"
-    t.integer "transaction_id"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
-    t.index ["transaction_id"], name: "index_versions_on_transaction_id"
   end
 
   add_foreign_key "flood_risk_engine_address_searches", "flood_risk_engine_enrollments", column: "enrollment_id"
@@ -300,6 +257,5 @@ ActiveRecord::Schema.define(version: 2021_06_24_113422) do
   add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_contacts", column: "contact_id"
   add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_contacts", column: "contact_id"
   add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_organisations", column: "organisation_id"
-  add_foreign_key "users_roles", "roles"
-  add_foreign_key "users_roles", "users"
+  add_foreign_key "transient_people", "transient_registrations"
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -208,6 +208,8 @@ ActiveRecord::Schema.define(version: 2021_06_29_072138) do
     t.string "addressable_type"
     t.string "uprn"
     t.string "token"
+    t.index ["addressable_id"], name: "index_transient_addresses_on_addressable_id", unique: true
+    t.index ["addressable_type"], name: "index_transient_addresses_on_addressable_type", unique: true
   end
 
   create_table "transient_people", force: :cascade do |t|

--- a/spec/factories/forms/additional_contact_email_form.rb
+++ b/spec/factories/forms/additional_contact_email_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :additional_contact_email_form, class: FloodRiskEngine::AdditionalContactEmailForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            additional_contact_email: "also_valid@example.com",
+            workflow_state: "additional_contact_email_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/business_type_form.rb
+++ b/spec/factories/forms/business_type_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :business_type_form, class: FloodRiskEngine::BusinessTypeForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            business_type: "limitedCompany",
+            workflow_state: "business_type_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/company_name_form.rb
+++ b/spec/factories/forms/company_name_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :company_name_form, class: FloodRiskEngine::CompanyNameForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            company_name: "Test Inc",
+            workflow_state: "company_name_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/company_number_form.rb
+++ b/spec/factories/forms/company_number_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :company_number_form, class: FloodRiskEngine::CompanyNumberForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            company_number: "10997904",
+            workflow_state: "company_number_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/company_postcode_form.rb
+++ b/spec/factories/forms/company_postcode_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :company_postcode_form, class: FloodRiskEngine::CompanyPostcodeForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            temp_company_postcode: "BS1 5AH",
+            workflow_state: "company_postcode_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/contact_email_form.rb
+++ b/spec/factories/forms/contact_email_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact_email_form, class: FloodRiskEngine::ContactEmailForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            contact_email: "valid@example.com",
+            workflow_state: "contact_email_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/contact_name_form.rb
+++ b/spec/factories/forms/contact_name_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact_name_form, class: FloodRiskEngine::ContactNameForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            contact_name: "Test Person",
+            workflow_state: "contact_name_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/contact_phone_form.rb
+++ b/spec/factories/forms/contact_phone_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact_phone_form, class: FloodRiskEngine::ContactPhoneForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            contact_phone: "03708 506 506",
+            workflow_state: "contact_phone_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/declaration_form.rb
+++ b/spec/factories/forms/declaration_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :declaration_form, class: FloodRiskEngine::DeclarationForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            declaration: true,
+            workflow_state: "declaration_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/forms/exemption_form.rb
+++ b/spec/factories/forms/exemption_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :exemption_form, class: FloodRiskEngine::ExemptionForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            workflow_state: "exemption_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/flood_risk_engine/additional_contact_email_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/additional_contact_email_forms_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe AdditionalContactEmailForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:additional_contact_email_form) { build(:additional_contact_email_form, :has_required_data) }
+        let(:valid_params) do
+          {
+            token: additional_contact_email_form.token,
+            additional_contact_email: additional_contact_email_form.additional_contact_email,
+            confirmed_email: additional_contact_email_form.additional_contact_email
+          }
+        end
+
+        it "should submit" do
+          expect(additional_contact_email_form.submit(ActionController::Parameters.new(valid_params))).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:additional_contact_email_form) { build(:additional_contact_email_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: "foo",
+            additional_contact_email: "foo"
+          }
+        end
+
+        it "should not submit" do
+          expect(additional_contact_email_form.submit(ActionController::Parameters.new(invalid_params))).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate email", :additional_contact_email_form, :additional_contact_email
+
+    context "when a valid transient registration exists" do
+      let(:additional_contact_email_form) { build(:additional_contact_email_form, :has_required_data) }
+
+      describe "#confirmed_email" do
+        context "when a confirmed_email meets the requirements" do
+          it "is valid" do
+            expect(additional_contact_email_form).to be_valid
+          end
+        end
+
+        context "when a confirmed_email does not match the additional_contact_email" do
+          before(:each) { additional_contact_email_form.confirmed_email = "no_matchy@example.com" }
+
+          it "is not valid" do
+            expect(additional_contact_email_form).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/flood_risk_engine/business_type_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/business_type_forms_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe BusinessTypeForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:business_type_form) { build(:business_type_form, :has_required_data) }
+        let(:valid_params) do
+          { token: business_type_form.token, business_type: business_type_form.business_type }
+        end
+
+        it "should submit" do
+          expect(business_type_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:business_type_form) { build(:business_type_form, :has_required_data) }
+        let(:invalid_params) { { business_type: "" } }
+
+        it "should not submit" do
+          expect(business_type_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate business_type", :business_type_form
+  end
+end

--- a/spec/forms/flood_risk_engine/company_name_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/company_name_forms_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe CompanyNameForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:company_name_form) { build(:company_name_form, :has_required_data) }
+        let(:valid_params) do
+          { token: company_name_form.token, company_name: company_name_form.company_name }
+        end
+
+        it "should submit" do
+          expect(company_name_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:company_name_form) { build(:company_name_form, :has_required_data) }
+        let(:invalid_params) { { company_name: "" } }
+
+        it "should not submit" do
+          expect(company_name_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate company_name", :company_name_form
+  end
+end

--- a/spec/forms/flood_risk_engine/company_number_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/company_number_forms_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe CompanyNumberForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:company_number_form) { build(:company_number_form, :has_required_data) }
+        let(:valid_params) do
+          { token: company_number_form.token, company_number: company_number_form.company_number }
+        end
+
+        it "should submit" do
+          expect(company_number_form.submit(valid_params)).to eq(true)
+        end
+
+        context "when the token is less than 8 characters" do
+          before(:each) { valid_params[:company_number] = "9764739" }
+
+          it "should increase the length" do
+            company_number_form.submit(valid_params)
+            expect(company_number_form.company_number).to eq("09764739")
+          end
+
+          it "should submit" do
+            expect(company_number_form.submit(valid_params)).to eq(true)
+          end
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:company_number_form) { build(:company_number_form, :has_required_data) }
+        let(:invalid_params) { { company_number: "" } }
+
+        it "should not submit" do
+          expect(company_number_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate company_number", :company_number_form
+  end
+end

--- a/spec/forms/flood_risk_engine/company_postcode_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/company_postcode_forms_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe CompanyPostcodeForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:company_postcode_form) { build(:company_postcode_form, :has_required_data) }
+        let(:valid_params) do
+          { token: company_postcode_form.token, temp_company_postcode: company_postcode_form.temp_company_postcode }
+        end
+
+        it "should submit" do
+          expect(company_postcode_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:company_postcode_form) { build(:company_postcode_form, :has_required_data) }
+        let(:invalid_params) { { temp_company_postcode: "" } }
+
+        it "should not submit" do
+          expect(company_postcode_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate postcode", :company_postcode_form, :temp_company_postcode
+  end
+end

--- a/spec/forms/flood_risk_engine/contact_email_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/contact_email_forms_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe ContactEmailForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:contact_email_form) { build(:contact_email_form, :has_required_data) }
+        let(:valid_params) do
+          {
+            token: contact_email_form.token,
+            contact_email: contact_email_form.contact_email,
+            confirmed_email: contact_email_form.contact_email
+          }
+        end
+
+        it "should submit" do
+          expect(contact_email_form.submit(ActionController::Parameters.new(valid_params))).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:contact_email_form) { build(:contact_email_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: "foo",
+            contact_email: "foo"
+          }
+        end
+
+        it "should not submit" do
+          expect(contact_email_form.submit(ActionController::Parameters.new(invalid_params))).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate email", :contact_email_form, :contact_email
+
+    context "when a valid transient registration exists" do
+      let(:contact_email_form) { build(:contact_email_form, :has_required_data) }
+
+      describe "#confirmed_email" do
+        context "when a confirmed_email meets the requirements" do
+          it "is valid" do
+            expect(contact_email_form).to be_valid
+          end
+        end
+
+        context "when a confirmed_email does not match the contact_email" do
+          before(:each) { contact_email_form.confirmed_email = "no_matchy@example.com" }
+
+          it "is not valid" do
+            expect(contact_email_form).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/flood_risk_engine/contact_name_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/contact_name_forms_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe ContactNameForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:contact_name_form) { build(:contact_name_form, :has_required_data) }
+        let(:valid_params) do
+          {
+            token: contact_name_form.token,
+            contact_name: contact_name_form.contact_name
+          }
+        end
+
+        it "should submit" do
+          expect(contact_name_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:contact_name_form) { build(:contact_name_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: "foo",
+            contact_name: "**Invalid_@_Name**",
+            contact_position: "**Invalid_@_Position**"
+          }
+        end
+
+        it "should not submit" do
+          expect(contact_name_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate contact name", :contact_name_form, :contact_name
+  end
+end

--- a/spec/forms/flood_risk_engine/contact_phone_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/contact_phone_forms_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe ContactPhoneForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:contact_phone_form) { build(:contact_phone_form, :has_required_data) }
+        let(:valid_params) do
+          {
+            token: contact_phone_form.token,
+            contact_phone: contact_phone_form.contact_phone
+          }
+        end
+
+        it "should submit" do
+          expect(contact_phone_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:contact_phone_form) { build(:contact_phone_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: "foo",
+            contact_phone: "foo"
+          }
+        end
+
+        it "should not submit" do
+          expect(contact_phone_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate contact_phone", :contact_phone_form
+  end
+end

--- a/spec/forms/flood_risk_engine/declaration_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/declaration_forms_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe DeclarationForm, type: :model do
+    describe "#submit" do
+      let(:declaration_form) { build(:declaration_form, :has_required_data) }
+
+      context "when the form is valid" do
+        let(:valid_params) do
+          {
+            token: declaration_form.token,
+            declaration: declaration_form.declaration
+          }
+        end
+
+        it "should submit" do
+          expect(declaration_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the declaration is blank" do
+        let(:declaration_form) { build(:declaration_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: declaration_form.token,
+            declaration: ""
+          }
+        end
+
+        it "should not submit" do
+          expect(declaration_form.submit(invalid_params)).to eq(false)
+        end
+      end
+
+      context "when the declaration is false" do
+        let(:declaration_form) { build(:declaration_form, :has_required_data) }
+        let(:invalid_params) do
+          {
+            token: declaration_form.token,
+            declaration: false
+          }
+        end
+
+        it "should not submit" do
+          expect(declaration_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/flood_risk_engine/exemption_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/exemption_forms_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe ExemptionForm, type: :model do
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:exemption) { create(:exemption) }
+        let(:exemption_form) { build(:exemption_form, :has_required_data) }
+        let(:valid_params) do
+          { token: exemption_form.token, exemption_ids: [exemption.id] }
+        end
+
+        it "should submit" do
+          expect(exemption_form.submit(valid_params)).to eq(true)
+        end
+
+        it "updates the transient registration with the selected exemption" do
+          transient_registration = exemption_form.transient_registration
+          expect(transient_registration.exemptions).to be_empty
+
+          exemption_form.submit(valid_params)
+
+          expect(transient_registration.exemptions.first.code).to eq(exemption.code)
+        end
+      end
+
+      context "when the form is not valid" do
+        let(:exemption_form) { build(:exemption_form, :has_required_data) }
+        let(:invalid_params) { { exemption_ids: [] } }
+
+        it "should not submit" do
+          expect(exemption_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+
+    include_examples "validate exemptions", :exemption_form
+  end
+end

--- a/spec/forms/flood_risk_engine/steps/declaration_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/declaration_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 module FloodRiskEngine
   module Steps
-    RSpec.describe DeclarationForm, type: :form do
+    RSpec.describe Steps::DeclarationForm, type: :form do
       let(:enrollment) { FactoryBot.create(:enrollment) }
       let(:model_class) { Enrollment }
       subject { described_class.factory(enrollment) }

--- a/spec/models/flood_risk_engine/transient_address_spec.rb
+++ b/spec/models/flood_risk_engine/transient_address_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe TransientAddress, type: :model do
+    subject(:transient_address) { create(:transient_address) }
+  end
+end

--- a/spec/models/flood_risk_engine/transient_person_spec.rb
+++ b/spec/models/flood_risk_engine/transient_person_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe TransientPerson, type: :model do
+    subject(:transient_person) { create(:transient_person) }
+  end
+end

--- a/spec/models/flood_risk_engine/transient_registration_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/transient_registration_exemption_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe TransientRegistrationExemption, type: :model do
+    subject(:transient_registration_exemption) { create(:transient_registration_exemption) }
+  end
+end

--- a/spec/requests/flood_risk_engine/additional_contact_email_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/additional_contact_email_forms_spec.rb
@@ -4,9 +4,21 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "AdditionalContactEmailForms", type: :request do
-    include_examples "GET flexible form", "additional_contact_email_form"
+    describe "GET additional_contact_email_form_path" do
+      include_examples "GET flexible form", "additional_contact_email_form"
+    end
 
-    include_examples "POST without params form", "additional_contact_email_form"
+    describe "POST additional_contact_email_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "additional_contact_email_form")
+      end
+
+      include_examples "POST form",
+                       "additional_contact_email_form",
+                       valid_params: { additional_contact_email: "valid@example.com",
+                                       confirmed_email: "valid@example.com" },
+                       invalid_params: { additional_contact_email: "foo" }
+    end
 
     describe "GET back_additional_contact_email_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/business_type_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/business_type_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "BusinessTypeForms", type: :request do
-    include_examples "GET flexible form", "business_type_form"
+    describe "GET business_type_form_path" do
+      include_examples "GET flexible form", "business_type_form"
+    end
 
-    include_examples "POST without params form", "business_type_form"
+    describe "POST business_type_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "business_type_form")
+      end
+
+      include_examples "POST form",
+                       "business_type_form",
+                       valid_params: { business_type: "limitedCompany" },
+                       invalid_params: { business_type: "" }
+    end
 
     describe "GET back_business_type_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/company_name_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_name_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "CompanyNameForms", type: :request do
-    include_examples "GET flexible form", "company_name_form"
+    describe "GET company_name_form_path" do
+      include_examples "GET flexible form", "company_name_form"
+    end
 
-    include_examples "POST without params form", "company_name_form"
+    describe "POST company_name_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "company_name_form")
+      end
+
+      include_examples "POST form",
+                       "company_name_form",
+                       valid_params: { company_name: "Test Inc" },
+                       invalid_params: { company_name: "" }
+    end
 
     describe "GET back_company_name_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/company_number_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_number_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "CompanyNumberForms", type: :request do
-    include_examples "GET flexible form", "company_number_form"
+    describe "GET company_number_form_path" do
+      include_examples "GET flexible form", "company_number_form"
+    end
 
-    include_examples "POST without params form", "company_number_form"
+    describe "POST company_number_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "company_number_form")
+      end
+
+      include_examples "POST form",
+                       "company_number_form",
+                       valid_params: { company_number: "10997904" },
+                       invalid_params: { company_number: "" }
+    end
 
     describe "GET back_company_number_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/company_postcode_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "CompanyPostcodeForms", type: :request do
-    include_examples "GET flexible form", "company_postcode_form"
+    describe "GET company_postcode_form_path" do
+      include_examples "GET flexible form", "company_postcode_form"
+    end
 
-    include_examples "POST without params form", "company_postcode_form"
+    describe "POST company_postcode_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "company_postcode_form")
+      end
+
+      include_examples "POST form",
+                       "company_postcode_form",
+                       valid_params: { temp_company_postcode: "BS1 5AH" },
+                       invalid_params: { temp_company_postcode: "" }
+    end
 
     describe "GET back_company_postcode_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/contact_email_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_email_forms_spec.rb
@@ -4,9 +4,21 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "ContactEmailForms", type: :request do
-    include_examples "GET flexible form", "contact_email_form"
+    describe "GET contact_email_form_path" do
+      include_examples "GET flexible form", "contact_email_form"
+    end
 
-    include_examples "POST without params form", "contact_email_form"
+    describe "POST contact_email_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "contact_email_form")
+      end
+
+      include_examples "POST form",
+                       "contact_email_form",
+                       valid_params: { contact_email: "valid@example.com",
+                                       confirmed_email: "valid@example.com" },
+                       invalid_params: { contact_email: "foo" }
+    end
 
     describe "GET back_contact_email_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/contact_name_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_name_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "ContactNameForms", type: :request do
-    include_examples "GET flexible form", "contact_name_form"
+    describe "GET contact_name_form_path" do
+      include_examples "GET flexible form", "contact_name_form"
+    end
 
-    include_examples "POST without params form", "contact_name_form"
+    describe "POST contact_name_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "contact_name_form")
+      end
+
+      include_examples "POST form",
+                       "contact_name_form",
+                       valid_params: { contact_name: "Contactable Person" },
+                       invalid_params: { contact_name: "" }
+    end
 
     describe "GET back_contact_name_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/contact_phone_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "ContactPhoneForms", type: :request do
-    include_examples "GET flexible form", "contact_phone_form"
+    describe "GET contact_phone_form_path" do
+      include_examples "GET flexible form", "contact_phone_form"
+    end
 
-    include_examples "POST without params form", "contact_phone_form"
+    describe "POST contact_phone_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "contact_phone_form")
+      end
+
+      include_examples "POST form",
+                       "contact_phone_form",
+                       valid_params: { contact_phone: "01234 567890" },
+                       invalid_params: { contact_phone: "foo" }
+    end
 
     describe "GET back_contact_phone_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/declaration_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/declaration_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "DeclarationForms", type: :request do
-    include_examples "GET locked-in form", "declaration_form"
+    describe "GET declaration_form_path" do
+      include_examples "GET locked-in form", "declaration_form"
+    end
 
-    include_examples "POST without params form", "declaration_form"
+    describe "POST declaration_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "declaration_form")
+      end
+
+      include_examples "POST form",
+                       "declaration_form",
+                       valid_params: { declaration: true },
+                       invalid_params: { declaration: "" }
+    end
 
     describe "GET back_declaration_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/requests/flood_risk_engine/exemption_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/exemption_forms_spec.rb
@@ -4,9 +4,20 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "ExemptionForms", type: :request do
-    include_examples "GET flexible form", "exemption_form"
+    describe "GET exemption_form_path" do
+      include_examples "GET flexible form", "exemption_form"
+    end
 
-    include_examples "POST without params form", "exemption_form"
+    describe "POST exemption_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "exemption_form")
+      end
+
+      include_examples "POST form",
+                       "exemption_form",
+                       valid_params: { exemption_ids: [FloodRiskEngine::Exemption.last.id] },
+                       invalid_params: { exemption_ids: [] }
+    end
 
     describe "GET back_exemption_forms_path" do
       context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# When a user submits a form, that form must match the expected workflow_state.
+# We don't adjust the state to match what the user is doing like we do for viewing forms.
+
+# We expect to receive the name of the form (for example, location_form), and a set of options.
+# Options can include valid params, invalid params, and an attribute to test persistence.
+RSpec.shared_examples "POST form" do |form, options|
+  let(:valid_params) { options[:valid_params] }
+  let(:invalid_params) { options[:invalid_params] }
+
+  context "when the params are valid" do
+    it "updates the transient registration's workflow_state and returns a 302 http status" do
+      state_before_request = transient_registration.workflow_state
+
+      post_form_with_params(form, transient_registration.token, valid_params)
+
+      transient_registration.reload
+
+      expect(transient_registration.workflow_state).to_not eq(state_before_request)
+      expect(response).to have_http_status(302)
+    end
+  end
+
+  context "when the params are invalid" do
+    it "does not update the transient registration's workflow_state, returns a 200 response and show the form again" do
+      state_before_request = transient_registration.workflow_state
+
+      post_form_with_params(form, transient_registration.token, invalid_params)
+
+      transient_registration.reload
+
+      expect(transient_registration.workflow_state).to eq(state_before_request)
+      expect(response).to have_http_status(200)
+      expect(response).to render_template("#{form}s/new")
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/validate_business_type.rb
+++ b/spec/support/shared_examples/validators/validate_business_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Tests for fields using the BusinessTypeValidator
+RSpec.shared_examples "validate business_type" do |form_factory|
+  it "validates the phone number using the BusinessTypeValidator class" do
+    validators = build(form_factory, :has_required_data)._validators
+    expect(validators.keys).to include(:business_type)
+    expect(validators[:business_type].first.class)
+      .to eq(DefraRuby::Validators::BusinessTypeValidator)
+  end
+end

--- a/spec/support/shared_examples/validators/validate_company_name.rb
+++ b/spec/support/shared_examples/validators/validate_company_name.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Tests for fields using the CompanyNameValidator
+RSpec.shared_examples "validate company_name" do |form_factory|
+  context "when a valid transient registration exists" do
+    let(:form) { build(form_factory, :has_required_data) }
+
+    context "when a company_name meets the requirements" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when a company_name is blank" do
+      before do
+        form.transient_registration.company_name = ""
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a company name is too long" do
+      # rubocop:disable Metrics/LineLength
+      before do
+        form.transient_registration.company_name = "ak67inm5ijij85w3a7gck67iloe2k98zyk01607xbhfqzznr4kbl5tuypqlbrpdvwqcup8ij9o2b0ryquhdmv5716s9zia3vz184g5vkhnk8869whwulmkqd47tqxveifrsg4wxpi0dbygo42k1ujdj8w4we2uvfvoamovk0u8ru5bk5esrxwxdue8sh7e03e3popgl2yzjvs5vk49xt5qtxaijdafdnlgc468jj4k21g3jumtsxc9nup8bgu83viakj0x6c47r7zfzxrr2nl3rn47v86odk6ra0e0dic7g7"
+      end
+      # rubocop:enable Metrics/LineLength
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/validate_company_number.rb
+++ b/spec/support/shared_examples/validators/validate_company_number.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Tests for fields using the CompanyNumberValidator
+RSpec.shared_examples "validate company_number" do |form_factory|
+  context "when a valid transient registration exists" do
+    let(:form) { build(form_factory, :has_required_data) }
+
+    context "when a company_number meets the requirements" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when a company_number is blank" do
+      before do
+        form.transient_registration.company_number = ""
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a company number is too long" do
+      before do
+        form.transient_registration.company_number = "ak67inm5ijij85w3a7gck"
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a company number is the wrong format" do
+      before do
+        form.transient_registration.company_number = "incorrect"
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/validate_contact_name.rb
+++ b/spec/support/shared_examples/validators/validate_contact_name.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Tests for fields using the ContactNameValidator
+RSpec.shared_examples "validate contact name" do |form_factory, field|
+  context "when a valid transient registration exists" do
+    let(:form) { build(form_factory, :has_required_data) }
+
+    context "when a name meets the requirements" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when a name is blank" do
+      before do
+        form.transient_registration.send("#{field}=", "")
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a name is too long" do
+      # rubocop:disable Metrics/LineLength
+      before do
+        form.transient_registration.send("#{field}=", "0fJQLDxvB77dz3SbcMDSH60kM82VUUMOlpZBkIUnh1IIUE0zF4r3NbHotPIzlbeQdCWB1qa")
+      end
+      # rubocop:enable Metrics/LineLength
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a name contains invalid characters" do
+      before do
+        form.transient_registration.send("#{field}=", "W@ste")
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/validate_contact_phone.rb
+++ b/spec/support/shared_examples/validators/validate_contact_phone.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Tests for fields using the PhoneNumberValidator
+RSpec.shared_examples "validate contact_phone" do |form_factory|
+  it "validates the phone number using the PhoneNumberValidator class" do
+    validators = build(form_factory, :has_required_data)._validators
+    expect(validators.keys).to include(:contact_phone)
+    expect(validators[:contact_phone].first.class)
+      .to eq(DefraRuby::Validators::PhoneNumberValidator)
+  end
+end

--- a/spec/support/shared_examples/validators/validate_email.rb
+++ b/spec/support/shared_examples/validators/validate_email.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Tests for fields using the EmailValidator
+RSpec.shared_examples "validate email" do |form_factory, field|
+  it "validates the #{field} using the EmailValidator class" do
+    validators = build(form_factory, :has_required_data)._validators
+    expect(validators.keys).to include(field)
+    expect(validators[field].first.class)
+      .to eq(DefraRuby::Validators::EmailValidator)
+  end
+end

--- a/spec/support/shared_examples/validators/validate_exemption.rb
+++ b/spec/support/shared_examples/validators/validate_exemption.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Tests for fields using the ExemptionsValidator
+RSpec.shared_examples "validate exemptions" do |form_factory|
+  it "validates exemptions using the ExemptionsValidator class" do
+    validators = build(form_factory, :has_required_data)._validators
+    expect(validators.keys).to include(:exemptions)
+    expect(validators[:exemptions].first.class)
+      .to eq(FloodRiskEngine::ExemptionsValidator)
+  end
+end

--- a/spec/support/shared_examples/validators/validate_postcode.rb
+++ b/spec/support/shared_examples/validators/validate_postcode.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Tests for fields using the PostcodeValidator
+RSpec.shared_examples "validate postcode" do |form_factory, field|
+  context "when a valid transient registration exists" do
+    let(:form) { build(form_factory, :has_required_data) }
+
+    context "when a postcode meets the requirements" do
+      before do
+        example_json = { postcode: "BS1 5AH" }
+        response = double(:response, results: [example_json], successful?: true)
+
+        expect(FloodRiskEngine::AddressLookupService).to receive(:run).and_return(response)
+      end
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when a postcode is blank" do
+      before do
+        form.transient_registration.send("#{field}=", "")
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a postcode is in the wrong format" do
+      before do
+        form.transient_registration.send("#{field}=", "")
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a postcode has no matches" do
+      before do
+        response = double(:response, successful?: false, error: DefraRuby::Address::NoMatchError.new)
+
+        expect(FloodRiskEngine::AddressLookupService).to receive(:run).and_return(response)
+      end
+
+      it "is not valid" do
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when a postcode search returns an error" do
+      before do
+        response = double(:response, successful?: false, error: "foo")
+
+        expect(FloodRiskEngine::AddressLookupService).to receive(:run).and_return(response)
+      end
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1473

This PR sets up the models and migrations for the various transient objects. As well as the transient registration, we also have an address, person and registration_exemption. Unlike WEX and WCR, in this case addresses can belong to partners rather than to the organisation, so we use polymorphic association.

It also includes form validations for these forms:

- exemption
- business type
- company name
- company number
- company postcode
- contact name
- contact phone
- contact email
- additional contact email
- declaration

Not included are the rest of the company address pages, the site location and the partner pages.