### PR TITLE
Add content to exemptions in the new workflow

### DIFF
--- a/app/controllers/flood_risk_engine/exemption_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/exemption_forms_controller.rb
@@ -13,7 +13,7 @@ module FloodRiskEngine
     private
 
     def transient_registration_attributes
-      params.fetch(:exemption_form, {}).permit(exemption_ids: [])
+      params.fetch(:exemption_form, {}).permit(:exemption_ids)
     end
   end
 end

--- a/app/forms/flood_risk_engine/exemption_form.rb
+++ b/app/forms/flood_risk_engine/exemption_form.rb
@@ -2,8 +2,26 @@
 
 module FloodRiskEngine
   class ExemptionForm < ::FloodRiskEngine::BaseForm
+    attr_accessor :exemption_ids
+
     delegate :exemptions, to: :transient_registration
 
     validates :exemptions, "flood_risk_engine/exemptions": true
+
+    after_initialize :assign_existing_exemption
+
+    def all_exemptions
+      @_all_exemptions ||= Exemption.all.map do |exemption|
+        ExemptionPresenter.new(exemption)
+      end
+    end
+
+    private
+
+    def assign_existing_exemption
+      return unless exemptions.any?
+
+      self.exemption_ids = exemptions.first.id
+    end
   end
 end

--- a/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
@@ -1,15 +1,51 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_confirm_exemption_forms_path(@confirm_exemption_form.token)) %>
 
-<div class="text">
-  <%= form_for(@confirm_exemption_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @confirm_exemption_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @confirm_exemption_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden"><%= t('.table_summary') %></span>
 
-    <%= hidden_field_tag :token, @confirm_exemption_form.token %>
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--l">
+          <%= t(".heading") %>
+        </caption>
+        <tbody class="govuk-table__body">
+          <% @confirm_exemption_form.transient_registration.exemptions.each do |exemption| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              <p><%= exemption.summary %></p>
+            </th>
+            <th scope="row" class="govuk-table__header">
+              <p><%= exemption.code %></p>
+            </th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <p>
+                <%=
+                  link_to(
+                    t(
+                      ".remove_link.text",
+                      hidden: content_tag(
+                        'span',
+                        t(
+                          ".remove_link.hidden",
+                          code: exemption.code
+                        ),
+                        class: "govuk-visually-hidden"
+                      )
+                    ).html_safe,
+                  back_confirm_exemption_forms_path(@confirm_exemption_form.token)
+                )
+                %>
+              </p>
+            </td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/flood_risk_engine/exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/exemption_forms/new.html.erb
@@ -1,15 +1,34 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_exemption_forms_path(@exemption_form.token)) %>
 
-<div class="text">
-  <%= form_for(@exemption_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @exemption_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @exemption_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <legend class="govuk-visually-hidden">
+        <%= t(".heading") %>
+      </legend>
 
-    <%= hidden_field_tag :token, @exemption_form.token %>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%=
+        f.govuk_collection_radio_buttons :exemption_ids,
+        @exemption_form.all_exemptions,
+        :id, :radio_button_label,
+        small: true,
+        legend: { text: "" },
+        hint: {
+          text:
+            [
+              t(".lead_paragraph.text_1"),
+              t(".lead_paragraph.text_2")
+            ].join("<br/>").html_safe
+        }
+      %>
+
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/flood_risk_engine/shared/_back.html.erb
+++ b/app/views/flood_risk_engine/shared/_back.html.erb
@@ -1,1 +1,9 @@
-<%= link_to(t(".back_link"), back_path, class: "link-back") %>
+<%
+  content_for :back_link do
+    link_to(
+        t(".back_link"),
+        back_path,
+        class: "govuk-back-link"
+      )
+  end
+%>

--- a/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
@@ -2,5 +2,10 @@ en:
   flood_risk_engine:
     confirm_exemption_forms:
       new:
-        heading: "Confirm exemption"
+        continue: Save and continue
+        heading: Confirm your exemption
+        remove_link:
+          text: Change %{hidden}
+          hidden: exemption %{code}
+        table_summary: Exemption and link to change it
         next_button: "Submit"

--- a/config/locales/flood_risk_engine/exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/exemption_forms.en.yml
@@ -2,5 +2,16 @@ en:
   flood_risk_engine:
     exemption_forms:
       new:
-        heading: "Select exemption"
+        heading: Select the exemption you want to register
+        lead_paragraph:
+          text_1: You can only register one exemption at a time.
+          text_2: If you need more than one, please make a new registration for each.
+          link: Exempt flood risk activities guidance
         next_button: "Submit"
+  activemodel:
+    errors:
+      models:
+        flood_risk_engine/exemption_form:
+          attributes:
+            exemptions:
+              inclusion: "Select an exemption"

--- a/spec/requests/flood_risk_engine/exemption_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/exemption_forms_spec.rb
@@ -15,8 +15,8 @@ module FloodRiskEngine
 
       include_examples "POST form",
                        "exemption_form",
-                       valid_params: { exemption_ids: [FloodRiskEngine::Exemption.last.id] },
-                       invalid_params: { exemption_ids: [] }
+                       valid_params: { exemption_ids: FloodRiskEngine::Exemption.last.id },
+                       invalid_params: { exemption_ids: nil }
     end
 
     describe "GET back_exemption_forms_path" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1460

This PR adds content for the forms to select and confirm an exemption, and saves the submitted data.

It also updates the styling for the back link.

---

Depends on https://github.com/DEFRA/flood-risk-engine/pull/400