### PR TITLE
Add content to site location page in new workflow

### DIFF
--- a/app/controllers/flood_risk_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/site_grid_reference_forms_controller.rb
@@ -9,5 +9,13 @@ module FloodRiskEngine
     def create
       super(SiteGridReferenceForm, "site_grid_reference_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:site_grid_reference_form, {}).permit(:temp_grid_reference,
+                                                         :temp_site_description,
+                                                         :dredging_length)
+    end
   end
 end

--- a/app/validators/flood_risk_engine/site_description_validator.rb
+++ b/app/validators/flood_risk_engine/site_description_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class SiteDescriptionValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+    include CanValidatePresence
+    include CanValidateLength
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+
+      max_length = 500
+      value_is_not_too_long?(record, attribute, value, max_length)
+    end
+  end
+end

--- a/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
@@ -1,15 +1,96 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
 
-<div class="text">
-  <%= form_for(@site_grid_reference_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @site_grid_reference_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @site_grid_reference_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden">
+        <%= t(".legend") %>
+      </span>
 
-    <%= hidden_field_tag :token, @site_grid_reference_form.token %>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= f.govuk_text_field :temp_grid_reference,
+            label: {
+              text: t(".grid_reference.form_label"),
+              size: "s"
+            },
+            width: "one-third",
+            hint: {
+              text:
+                [
+                  t(".grid_reference.example_hint"),
+                  t(".grid_reference.clarification_hint")
+                ].join("<br/>").html_safe
+            }
+          %>
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                <%= t(".details.summary") %>
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p>
+                <%=
+                  t(".details.tool_text",
+                    link: link_to( t(".details.tool_link"), "http://gridreferencefinder.com/",
+                    rel: "external",
+                    target: "_blank")
+                  ).html_safe
+                %>
+              </p>
+              <ol class="govuk-list govuk-list--number">
+                <li><%= t(".details.bullet1") %></li>
+                <li><%= t(".details.bullet2") %></li>
+                <li><%= t(".details.bullet3") %></li>
+              </ol>
+            </div>
+          </details>
+
+          <% if @site_grid_reference_form.require_dredging_length? %>
+            <%= f.govuk_number_field :dredging_length,
+              label: {
+                text: t(".dredging_length.form_label"),
+                size: "s"
+              },
+              width: 5,
+              suffix_text: t(".dredging_length.units"),
+            hint: {
+                text:
+                  [
+                    t(".dredging_length.clarification_hint"),
+                    t(".dredging_length.units")
+                  ].join("<br/>").html_safe
+              }
+            %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <%= f.govuk_text_area :temp_site_description,
+            label: {
+              text: t(".description.form_label"),
+              size: "s"
+            },
+          hint: {
+              text: t(".description.clarification_hint")
+            },
+            max_chars: 500
+          %>
+        </div>
+      </div>
+
+
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
+++ b/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
@@ -2,5 +2,39 @@ en:
   flood_risk_engine:
     site_grid_reference_forms:
       new:
-        heading: "Site grid reference"
+        heading: Where will the activity take place?
+        legend: Where will the activity take place?
+        grid_reference:
+          form_label: National Grid reference
+          example_hint: Enter 2 letters and 10 digits. For example, ST 58132 72695.
+          clarification_hint: |-
+            For activities that take place over a stretch of the watercourse
+            choose the middle or centre point.
+        dredging_length:
+          form_label: Approximate length of dredging in metres
+          clarification_hint: The maximum length you can dredge is 1,500 metres
+          units: metres
+        description:
+          form_label: Site name or description
+          clarification_hint: |-
+            For example, river name, place name, landmarks, or built or natural
+            features
+          length_hint: "%{max} character limit"
+        details:
+          summary: Help finding a grid reference
+          tool_text: Use the free %{link}
+          tool_link: UK Grid Reference Finder (opens new window).
+          bullet1:  Search for the location or postcode on the left of the page.
+          bullet2:  Right-click to display the grid reference.
+          bullet3:  Select the grid reference then copy and paste back on this page.
+        errors:
+          grid_reference:
+            invalid: The grid reference should have 2 letters and 10 digits
+            blank: Enter a National Grid reference
+          description:
+            too_long: The site name or description must be no longer than %{max} characters
+            blank: Enter a site name or description
+          dredging_length:
+            blank: Enter the approximate length of dredging
+            numeric: The length of dredging must be a number between %{min} and %{max}
         next_button: "Submit"

--- a/db/migrate/20210802151907_add_dredging_length_to_transient_registration.rb
+++ b/db/migrate/20210802151907_add_dredging_length_to_transient_registration.rb
@@ -1,0 +1,5 @@
+class AddDredgingLengthToTransientRegistration < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transient_registrations, :dredging_length, :integer
+  end
+end

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -32,7 +32,8 @@ module FloodRiskEngine
 
     config_accessor(:redirection_url_postcode_lookup)
     config_accessor(:layout) { "application" }
-    config_accessor(:minumum_dredging_length_in_metres) { 1 }
+    config_accessor(:minumum_dredging_length_in_metres) { 1 } # TYPO - left in for legacy purposes
+    config_accessor(:minimum_dredging_length_in_metres) { 1 }
     config_accessor(:maximum_dredging_length_in_metres) { 1500 }
     config_accessor(:maximum_company_name_length) { 170 }
     config_accessor(:maximum_individual_name_length) { 170 }

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_29_072138) do
+ActiveRecord::Schema.define(version: 2021_08_02_151907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_072138) do
     t.string "temp_grid_reference"
     t.text "temp_site_description"
     t.boolean "address_finder_error", default: false
+    t.integer "dredging_length"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/factories/forms/site_grid_reference_form.rb
+++ b/spec/factories/forms/site_grid_reference_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_grid_reference_form, class: FloodRiskEngine::SiteGridReferenceForm do
+    trait :has_required_data do
+      initialize_with do
+        new(
+          create(
+            :new_registration,
+            workflow_state: "site_grid_reference_form"
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/site_grid_reference_forms_spec.rb
@@ -4,9 +4,24 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "SiteGridReferenceForms", type: :request do
-    include_examples "GET flexible form", "site_grid_reference_form"
+    describe "GET site_grid_reference_form_path" do
+      include_examples "GET flexible form", "site_grid_reference_form"
+    end
 
-    include_examples "POST without params form", "site_grid_reference_form"
+    describe "POST site_grid_reference_form_path" do
+      let(:transient_registration) do
+        create(:new_registration, workflow_state: "site_grid_reference_form")
+      end
+
+      include_examples "POST form",
+                       "site_grid_reference_form",
+                       valid_params: {
+                         temp_grid_reference: "ST 5813272695",
+                         temp_site_description: "foo",
+                         dredging_length: "99"
+                       },
+                       invalid_params: { temp_grid_reference: nil }
+    end
 
     describe "GET back_site_grid_reference_forms_path" do
       context "when a valid transient registration exists" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1461

This PR adds the form content and validation for the site location page.

It also includes a migration to add an additional field to the transient registration for the dredging length, which is only used for one exemption.

---

Depends on https://github.com/DEFRA/flood-risk-engine/pull/401