### PR TITLE
Add content to contact pages in new workflow

### DIFF
--- a/app/forms/flood_risk_engine/additional_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/additional_contact_email_form.rb
@@ -5,11 +5,13 @@ module FloodRiskEngine
     delegate :additional_contact_email, to: :transient_registration
     attr_accessor :confirmed_email
 
-    validates :additional_contact_email, "defra_ruby/validators/email": true
+    validates :additional_contact_email, "defra_ruby/validators/email": true, if: :emails_are_populated?
     validates :confirmed_email, "defra_ruby/validators/email": {
       messages: custom_error_messages(:confirmed_email, :blank, :invalid_format)
-    }
-    validates :confirmed_email, "flood_risk_engine/matching_email": { compare_to: :additional_contact_email }
+    }, if: :emails_are_populated?
+    validates :confirmed_email, "flood_risk_engine/matching_email": {
+      compare_to: :additional_contact_email
+    }, if: :emails_are_populated?
 
     after_initialize :populate_confirmed_email
 
@@ -24,6 +26,10 @@ module FloodRiskEngine
 
     def populate_confirmed_email
       self.confirmed_email = additional_contact_email
+    end
+
+    def emails_are_populated?
+      additional_contact_email.present? || confirmed_email.present?
     end
   end
 end

--- a/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
@@ -1,15 +1,31 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_additional_contact_email_forms_path(@additional_contact_email_form.token)) %>
 
-<div class="text">
-  <%= form_for(@additional_contact_email_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @additional_contact_email_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @additional_contact_email_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden">
+        <%= t(".legend") %>
+      </span>
 
-    <%= hidden_field_tag :token, @additional_contact_email_form.token %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">
+            <%= t(".heading") %>
+          </h1>
+          <%= f.govuk_email_field :additional_contact_email,
+            width: 20,
+            label: { text: t(".email_address.label") }
+          %>
+          <%= f.govuk_email_field :confirmed_email,
+            width: 20,
+            label: { text: t(".email_address_confirmation.label") }
+          %>
+        </div>
+      </div>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/flood_risk_engine/contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_email_forms/new.html.erb
@@ -1,15 +1,34 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_contact_email_forms_path(@contact_email_form.token)) %>
 
-<div class="text">
-  <%= form_for(@contact_email_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @contact_email_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @contact_email_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden">
+        <%= t(".legend") %>
+      </span>
 
-    <%= hidden_field_tag :token, @contact_email_form.token %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">
+            <%= t(".heading") %>
+          </h1>
+          <%= f.govuk_email_field :contact_email,
+            width: 20,
+            label: {
+              text: t(".label")
+            },
+            hint: { text: t(".form_hint") }
+          %>
+          <%= f.govuk_email_field :confirmed_email,
+            width: 20,
+            label: {  text: t(".label1") }
+          %>
+        </div>
+      </div>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/flood_risk_engine/contact_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_name_forms/new.html.erb
@@ -1,15 +1,32 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_contact_name_forms_path(@contact_name_form.token)) %>
 
-<div class="text">
-  <%= form_for(@contact_name_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @contact_name_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @contact_name_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden">
+        <%= t(".legend") %>
+      </span>
 
-    <%= hidden_field_tag :token, @contact_name_form.token %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">
+            <%= t(".heading") %>
+          </h1>
+          <%= f.govuk_text_field :contact_name,
+            width: 20,
+            label: { text: t(".label") },
+            hint: { text: t(".form_hint_1") }
+          %>
+          <%= f.govuk_text_field :contact_position,
+            width: 20,
+            label: { text: t(".label1") }
+          %>
+        </div>
+      </div>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
@@ -1,15 +1,28 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_contact_phone_forms_path(@contact_phone_form.token)) %>
 
-<div class="text">
-  <%= form_for(@contact_phone_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @contact_phone_form) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @contact_phone_form do |f| %>
+      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+      <span class="govuk-visually-hidden">
+        <%= t(".legend") %>
+      </span>
 
-    <%= hidden_field_tag :token, @contact_phone_form.token %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">
+            <%= t(".heading") %>
+          </h1>
+          <%= f.govuk_phone_field :contact_phone,
+            width: 10,
+            label: { text: t(".form_label") },
+            hint: { text: t(".form_hint") }
+          %>
+        </div>
+      </div>
 
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
-  <% end %>
+      <%= f.govuk_submit t(".next_button") %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/flood_risk_engine/additional_contact_email_forms.en.yml
+++ b/config/locales/flood_risk_engine/additional_contact_email_forms.en.yml
@@ -2,5 +2,26 @@ en:
   flood_risk_engine:
     additional_contact_email_forms:
       new:
-        heading: "Additional contact email"
+        heading: Would you also like a copy of the confirmation email sent to someone else?
+        legend: Would you also like a copy of the confirmation email sent to someone else?
+        clarification: We’ll send a confirmation to the main contact.
+          We will also send a copy to another address if you want.
+        email_address:
+          label: Email address for confirmation copy (optional)
+        email_address_confirmation:
+          label: Confirm email address if entered above
         next_button: "Submit"
+  activemodel:
+      errors:
+        models:
+          flood_risk_engine/additional_contact_email_form:
+            attributes:
+              confirmed_email:
+                blank: "Enter the email address again to confirm it"
+                invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"
+                does_not_match: "The email addresses you’ve entered don’t match"
+  defra_ruby:
+    validators:
+      EmailValidator:
+        blank: "Enter an email address"
+        invalid_format: "Enter a valid email address - there’s a mistake in that one"

--- a/config/locales/flood_risk_engine/contact_email_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_email_forms.en.yml
@@ -2,5 +2,31 @@ en:
   flood_risk_engine:
     contact_email_forms:
       new:
-        heading: "Contact email"
+        form_hint: "We’ll send a confirmation to this address"
+        heading: "What’s the email address of the person we should contact?"
+        label:  Email address
+        hint:  "We’ll send the registration confirmation to this address"
+        label1: Confirm email address
+        legend: What’s the email address of the person we should contact?
+        errors:
+          email_address:
+            blank: Enter an email address
+            format: "Enter a valid email address - there’s a mistake in that one"
+          email_address_confirmation:
+            blank: Enter your email address again to confirm it
+            format: "The email addresses you’ve entered don’t match"
         next_button: "Submit"
+  activemodel:
+      errors:
+        models:
+          flood_risk_engine/contact_email_form:
+            attributes:
+              confirmed_email:
+                blank: "Enter the email address again to confirm it"
+                invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"
+                does_not_match: "The email addresses you’ve entered don’t match"
+  defra_ruby:
+    validators:
+      EmailValidator:
+        blank: "Enter an email address"
+        invalid_format: "Enter a valid email address - there’s a mistake in that one"

--- a/config/locales/flood_risk_engine/contact_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_name_forms.en.yml
@@ -2,5 +2,27 @@ en:
   flood_risk_engine:
     contact_name_forms:
       new:
-        heading: "Contact name"
+        heading: Who should we contact about this activity?
+        label: Enter a full name
+        form_hint_1: For example, John Smith
+        label1: Enter a job title, if applicable (optional)
+        form_hint_2: For example, Project Manager
+        legend: Who should we contact about this activity?
+        para_text: We may need to contact someone to check details of the activities or arrange a site visit.
+          We’ll send a confirmation of your registration to this person.
+          You can add another email address later if someone else needs a copy of the confirmation.
         next_button: "Submit"
+  activemodel:
+    errors:
+      models:
+        flood_risk_engine/contact_name_form:
+          attributes:
+            contact_name:
+              blank: Enter a name
+              invalid: "The name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "The name must have no more than 70 characters"
+  defra_ruby:
+    validators:
+      PositionValidator:
+        invalid_format: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+        too_long: "The position must have no more than 70 characters"

--- a/config/locales/flood_risk_engine/contact_phone_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_phone_forms.en.yml
@@ -2,5 +2,18 @@ en:
   flood_risk_engine:
     contact_phone_forms:
       new:
-        heading: "Contact phone"
+        heading: What’s the telephone number of the person we should contact?
+        form_label: Telephone number
+        form_hint: This can be a landline or mobile
+        legend: What’s the telephone number of the person we should contact?
+        errors:
+          telephone_number:
+            invalid: Enter a valid telephone number
+            blank: Enter a telephone number
         next_button: "Submit"
+  defra_ruby:
+    validators:
+      PhoneNumberValidator:
+        blank: "Enter a telephone number"
+        invalid_format: "Enter a valid telephone number"
+        too_long: "Check the number you entered - it should have no more than than 15 characters"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1463

This PR adds content to the contact pages - name, phone number, email and additional email.

It also updates the validation rules on the additional contact email to make sure it is optional rather than required.

---

Relies on https://github.com/DEFRA/flood-risk-engine/pull/402