### PR TITLE
Add content to Check Your Answers form

### DIFF
--- a/app/forms/flood_risk_engine/check_your_answers_form.rb
+++ b/app/forms/flood_risk_engine/check_your_answers_form.rb
@@ -2,11 +2,12 @@
 
 module FloodRiskEngine
   class CheckYourAnswersForm < ::FloodRiskEngine::BaseForm
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
+    delegate :rows, to: :check_your_answers_presenter
 
-      super(attributes)
+    private
+
+    def check_your_answers_presenter
+      @_check_your_answers_presenter ||= CheckYourAnswersPresenter.new(transient_registration)
     end
   end
 end

--- a/app/presenters/flood_risk_engine/check_your_answers_presenter.rb
+++ b/app/presenters/flood_risk_engine/check_your_answers_presenter.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength
+module FloodRiskEngine
+  class CheckYourAnswersPresenter < BasePresenter
+    def initialize(transient_registration)
+      super(transient_registration, nil)
+    end
+
+    def rows
+      [
+        exemption_row,
+        location_rows,
+        company_rows,
+        contact_rows
+      ].flatten
+    end
+
+    private
+
+    def location_rows
+      row_array = [grid_reference_row, site_description_row]
+      row_array << dredging_length_row if dredging_length.present?
+
+      row_array
+    end
+
+    def company_rows
+      row_array = [business_type_row]
+
+      if partnership?
+        transient_people.each { |partner| row_array << partner_row(partner) }
+      else
+        row_array += [company_name_row, company_address_row]
+      end
+
+      row_array
+    end
+
+    def contact_rows
+      [contact_name_row, contact_phone_row, contact_email_row]
+    end
+
+    def exemption_row
+      exemption = exemptions.first
+
+      {
+        title: I18n.t("#{i18n_scope}.exemption.title", code: exemption.code),
+        value: exemption.summary
+      }
+    end
+
+    def grid_reference_row
+      {
+        title: I18n.t("#{i18n_scope}.grid_reference.title"),
+        value: temp_grid_reference
+      }
+    end
+
+    def site_description_row
+      {
+        title: I18n.t("#{i18n_scope}.site_description.title"),
+        value: temp_site_description
+      }
+    end
+
+    def dredging_length_row
+      {
+        title: I18n.t("#{i18n_scope}.dredging_length.title"),
+        value: I18n.t("#{i18n_scope}.dredging_length.value",
+                      dredging_length: dredging_length,
+                      count: dredging_length)
+      }
+    end
+
+    def business_type_row
+      formatted_business_type = FloodRiskEngine::TransientRegistration::BUSINESS_TYPES.key(business_type)
+
+      {
+        title: I18n.t("#{i18n_scope}.business_type.title"),
+        value: I18n.t("#{i18n_scope}.business_type.value.#{formatted_business_type}")
+      }
+    end
+
+    def company_name_row
+      {
+        title: I18n.t("#{i18n_scope}.company_name.title"),
+        value: company_name
+      }
+    end
+
+    def company_address_row
+      {
+        title: I18n.t("#{i18n_scope}.company_address.title"),
+        value: displayable_address(company_address)
+      }
+    end
+
+    def partner_row(partner)
+      value = [partner.full_name, displayable_address(partner.transient_address)].join(", ")
+
+      {
+        title: I18n.t("#{i18n_scope}.partner.title"),
+        value: value
+      }
+    end
+
+    def contact_name_row
+      value = if contact_position.present?
+                I18n.t("#{i18n_scope}.contact_name.value.position",
+                       contact_name: contact_name,
+                       contact_position: contact_position)
+              else
+                I18n.t("#{i18n_scope}.contact_name.value.no_position",
+                       contact_name: contact_name)
+              end
+      {
+        title: I18n.t("#{i18n_scope}.contact_name.title"),
+        value: value
+      }
+    end
+
+    def contact_phone_row
+      {
+        title: I18n.t("#{i18n_scope}.contact_phone.title"),
+        value: contact_phone
+      }
+    end
+
+    def contact_email_row
+      {
+        title: I18n.t("#{i18n_scope}.contact_email.title"),
+        value: contact_email
+      }
+    end
+
+    def displayable_address(address)
+      [address.organisation, address.premises, address.street_address,
+       address.locality, address.city, address.postcode].reject(&:blank?).join(", ")
+    end
+
+    def i18n_scope
+      "flood_risk_engine.check_your_answers_forms.new.rows"
+    end
+  end
+end
+# rubocop:enable Metrics/ClassLength

--- a/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
@@ -1,15 +1,37 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_check_your_answers_forms_path(@check_your_answers_form.token)) %>
 
-<div class="text">
-  <%= form_for(@check_your_answers_form) do |f| %>
-    <%= render("flood_risk_engine/shared/errors", object: @check_your_answers_form) %>
+<div class="govuk-grid-row">
+  <%= form_for @check_your_answers_form do |f| %>
+    <h1 class="govuk-heading-l">
+      <%= t(".heading") %>
+    </h1>
+    <h2 class="govuk-heading-m">
+      <%= t(".table_heading") %>
+    </h2>
+    <span class="govuk-visually-hidden"><%= t(".table_summary") %></span>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <% @check_your_answers_form.rows.each do |row| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= row[:title] %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= row[:value] %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <% if row[:change_url].present? %>
+              <%= link_to(row[:change_url]) do %>
+                <%= t(".change_link")%>
+                <span class="govuk-visually-hidden">
+                  <%= row[:change_link_suffix] %>
+                </span>
+              <% end %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
-
-    <%= hidden_field_tag :token, @check_your_answers_form.token %>
-
-    <div class="form-group">
-      <%= f.submit t(".next_button"), class: "button" %>
-    </div>
+    <%= f.govuk_submit t(".next_button") %>
   <% end %>
 </div>

--- a/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
+++ b/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
@@ -2,5 +2,59 @@ en:
   flood_risk_engine:
     check_your_answers_forms:
       new:
-        heading: "Check your answers"
+        heading: Check your answers before completing this registration
+        subheading: We’ll send a copy of these details in the confirmation email.
+        table_heading: Registration details
+        table_summary: "The information you've given us"
+        change_link: Change
+        rows:
+          organisation_registration_number:
+            title: Company registration number
+            accessible_change_link_suffix: company registration number
+          business_type:
+            title: Customer type
+            value:
+              sole_trader: "Sole trader"
+              limited_company: "Limited company"
+              partnership: "Partnership"
+              limited_liability_partnership: "Limited liability partnership"
+              local_authority: "Local authority"
+              charity: "Charity"
+            accessible_change_link_suffix: customer type
+          grid_reference:
+            title: Grid reference
+            accessible_change_link_suffix: grid reference
+          exemption:
+            title: Exemption %{code}
+            accessible_change_link_suffix: exemption %{code}
+          site_description:
+            title: Site description
+            accessible_change_link_suffix: site description
+          dredging_length:
+            title: Dredging length
+            value:
+              one: "%{dredging_length} metre"
+              other: "%{dredging_length} metres"
+            accessible_change_link_suffix: dredging length
+          company_name:
+            title: Responsible for activity (‘operator’)
+            accessible_change_link_suffix: operator
+          company_address:
+            title: Their address
+            accessible_change_link_suffix: their address
+          contact_name:
+            title: Who we will contact
+            value:
+              position: "%{contact_name} (%{contact_position})"
+              no_position: "%{contact_name}"
+            accessible_change_link_suffix: who we will contact
+          contact_phone:
+            title: Telephone
+            accessible_change_link_suffix: telephone
+          contact_email:
+            title: Email
+            accessible_change_link_suffix: email
+          partner:
+            title: Details of responsible partner
+            accessible_change_link_suffix: responsible partner
         next_button: "Submit"

--- a/spec/factories/new_registrations_factory.rb
+++ b/spec/factories/new_registrations_factory.rb
@@ -13,5 +13,34 @@ FactoryBot.define do
     trait :has_named_partner_with_postcode do
       transient_people { [build(:transient_person, :named, :has_temp_postcode)] }
     end
+
+    trait :has_required_data do
+      additional_contact_email { Faker::Name.name }
+      business_type { "soleTrader" }
+      company_name { Faker::Company.name }
+      contact_email { generate(:random_email) }
+      contact_name { Faker::Name.name }
+      contact_phone { Faker::PhoneNumber.phone_number }
+      contact_position { Faker::Company.profession }
+      temp_grid_reference { Faker::Number.number(digits: 10) }
+      temp_site_description { Faker::Lorem.sentence }
+
+      exemptions { [build(:exemption)] }
+    end
+
+    trait :has_required_data_for_limited_company do
+      has_required_data
+      has_company_address
+
+      business_type { "limitedCompany" }
+      company_number { Faker::Number.number(digits: 8) }
+    end
+
+    trait :has_required_data_for_partnership do
+      has_required_data
+
+      business_type { "partnership" }
+      transient_people { build_list(:transient_person, 2, :named, :completed) }
+    end
   end
 end

--- a/spec/presenters/flood_risk_engine/check_your_answers_presenter_spec.rb
+++ b/spec/presenters/flood_risk_engine/check_your_answers_presenter_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe CheckYourAnswersPresenter, type: :presenter do
+    let(:new_registration) do
+      build(:new_registration,
+            :has_required_data_for_limited_company)
+    end
+
+    subject do
+      described_class.new(new_registration)
+    end
+
+    let(:expected_data) do
+      [
+        {
+          title: "Exemption #{new_registration.exemptions.first.code}",
+          value: new_registration.exemptions.first.summary
+        },
+        {
+          title: "Grid reference",
+          value: new_registration.temp_grid_reference
+        },
+        {
+          title: "Site description",
+          value: new_registration.temp_site_description
+        },
+        {
+          title: "Customer type",
+          value: "Limited company"
+        },
+        {
+          title: "Responsible for activity (‘operator’)",
+          value: new_registration.company_name
+        },
+        {
+          title: "Their address",
+          value: [
+            new_registration.try(:company_address).try(:organisation),
+            new_registration.try(:company_address).try(:premises),
+            new_registration.try(:company_address).try(:street_address),
+            new_registration.try(:company_address).try(:locality),
+            new_registration.try(:company_address).try(:city),
+            new_registration.try(:company_address).try(:postcode)
+          ].join(", ")
+        },
+        {
+          title: "Who we will contact",
+          value: "#{new_registration.contact_name} (#{new_registration.contact_position})"
+        },
+        {
+          title: "Telephone",
+          value: new_registration.contact_phone
+        },
+        {
+          title: "Email",
+          value: new_registration.contact_email
+        }
+      ]
+    end
+
+    it "returns the properly-formatted data" do
+      expect(subject.rows).to eq(expected_data)
+    end
+
+    context "when the registration is a partnership" do
+      let(:new_registration) do
+        build(:new_registration,
+              :has_required_data_for_partnership)
+      end
+
+      before do
+        first_partner = new_registration.transient_people.first
+        first_partner_text = [
+          first_partner.full_name,
+          first_partner.transient_address.organisation,
+          first_partner.transient_address.premises,
+          first_partner.transient_address.street_address,
+          first_partner.transient_address.locality,
+          first_partner.transient_address.city,
+          first_partner.transient_address.postcode
+        ].join(", ")
+
+        second_partner = new_registration.transient_people.last
+        second_partner_text = [
+          second_partner.full_name,
+          second_partner.transient_address.organisation,
+          second_partner.transient_address.premises,
+          second_partner.transient_address.street_address,
+          second_partner.transient_address.locality,
+          second_partner.transient_address.city,
+          second_partner.transient_address.postcode
+        ].join(", ")
+
+        expected_data[3][:value] = "Partnership"
+        expected_data.delete_at(4)
+        expected_data.delete_at(4)
+        expected_data.insert(4, title: "Details of responsible partner", value: first_partner_text)
+        expected_data.insert(5, title: "Details of responsible partner", value: second_partner_text)
+      end
+
+      it "returns the properly-formatted data" do
+        expect(subject.rows).to eq(expected_data)
+      end
+    end
+
+    context "when the registration has a FRA23 exemption" do
+      before do
+        new_registration.exemptions = [build(:exemption, code: "FRA23")]
+        new_registration.dredging_length = 5
+
+        expected_data.insert(3, title: "Dredging length", value: "#{new_registration.dredging_length} metres")
+      end
+
+      it "returns the properly-formatted data" do
+        expect(subject.rows).to eq(expected_data)
+      end
+    end
+
+    context "when the registration has no contact position" do
+      before do
+        new_registration.contact_position = nil
+        expected_data[6][:value] = new_registration.contact_name
+      end
+
+      it "returns the properly-formatted data" do
+        expect(subject.rows).to eq(expected_data)
+      end
+    end
+  end
+end

--- a/spec/requests/flood_risk_engine/check_your_answers_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/check_your_answers_forms_spec.rb
@@ -4,9 +4,19 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe "CheckYourAnswersForms", type: :request do
-    include_examples "GET flexible form", "check_your_answers_form"
 
-    include_examples "POST without params form", "check_your_answers_form"
+    describe "GET check_your_answers_form_path" do
+      before do
+        transient_registration.exemptions = [build(:exemption)]
+        transient_registration.company_address = build(:transient_address, :company)
+      end
+
+      include_examples "GET flexible form", "check_your_answers_form"
+    end
+
+    describe "POST check_your_answers_form_path" do
+      include_examples "POST without params form", "check_your_answers_form"
+    end
 
     describe "GET back_check_your_answers_forms_path" do
       context "when a valid transient registration exists" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1464

This doesn't display all data the user entered - for example, the additional contact email and registration number are missed out. But that was the behaviour of the old check your answers page as well.