### PR TITLE
Fix content and formatting errors on new registration forms

### DIFF
--- a/app/forms/flood_risk_engine/check_your_answers_form.rb
+++ b/app/forms/flood_risk_engine/check_your_answers_form.rb
@@ -2,7 +2,7 @@
 
 module FloodRiskEngine
   class CheckYourAnswersForm < ::FloodRiskEngine::BaseForm
-    delegate :rows, to: :check_your_answers_presenter
+    delegate :registration_rows, :contact_rows, to: :check_your_answers_presenter
 
     private
 

--- a/app/models/concerns/flood_risk_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/flood_risk_engine/can_have_registration_attributes.rb
@@ -5,11 +5,11 @@ module FloodRiskEngine
     extend ActiveSupport::Concern
 
     BUSINESS_TYPES = HashWithIndifferentAccess.new(
-      sole_trader: "soleTrader",
-      limited_company: "limitedCompany",
-      partnership: "partnership",
-      limited_liability_partnership: "limitedLiabilityPartnership",
       local_authority: "localAuthority",
+      limited_company: "limitedCompany",
+      limited_liability_partnership: "limitedLiabilityPartnership",
+      sole_trader: "soleTrader",
+      partnership: "partnership",
       charity: "charity"
     )
 

--- a/app/presenters/flood_risk_engine/check_your_answers_presenter.rb
+++ b/app/presenters/flood_risk_engine/check_your_answers_presenter.rb
@@ -7,13 +7,19 @@ module FloodRiskEngine
       super(transient_registration, nil)
     end
 
-    def rows
+    def registration_rows
       [
         exemption_row,
         location_rows,
-        company_rows,
-        contact_rows
+        company_rows
       ].flatten
+    end
+
+    def contact_rows
+      row_array = [contact_name_row, contact_phone_row, contact_email_row]
+      row_array << additional_contact_email_row if additional_contact_email.present?
+
+      row_array
     end
 
     private
@@ -31,22 +37,19 @@ module FloodRiskEngine
       if partnership?
         transient_people.each { |partner| row_array << partner_row(partner) }
       else
+        row_array << company_number_row if company_no_required?
         row_array += [company_name_row, company_address_row]
       end
 
       row_array
     end
 
-    def contact_rows
-      [contact_name_row, contact_phone_row, contact_email_row]
-    end
-
     def exemption_row
       exemption = exemptions.first
 
       {
-        title: I18n.t("#{i18n_scope}.exemption.title", code: exemption.code),
-        value: exemption.summary
+        title: I18n.t("#{i18n_scope}.exemption.title"),
+        value: "#{exemption.code} #{exemption.summary}"
       }
     end
 
@@ -79,6 +82,13 @@ module FloodRiskEngine
       {
         title: I18n.t("#{i18n_scope}.business_type.title"),
         value: I18n.t("#{i18n_scope}.business_type.value.#{formatted_business_type}")
+      }
+    end
+
+    def company_number_row
+      {
+        title: I18n.t("#{i18n_scope}.company_number.title"),
+        value: company_number
       }
     end
 
@@ -131,6 +141,13 @@ module FloodRiskEngine
       {
         title: I18n.t("#{i18n_scope}.contact_email.title"),
         value: contact_email
+      }
+    end
+
+    def additional_contact_email_row
+      {
+        title: I18n.t("#{i18n_scope}.additional_contact_email.title"),
+        value: additional_contact_email
       }
     end
 

--- a/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/additional_contact_email_forms/new.html.erb
@@ -9,21 +9,20 @@
         <%= t(".legend") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">
-            <%= t(".heading") %>
-          </h1>
-          <%= f.govuk_email_field :additional_contact_email,
-            width: 20,
-            label: { text: t(".email_address.label") }
-          %>
-          <%= f.govuk_email_field :confirmed_email,
-            width: 20,
-            label: { text: t(".email_address_confirmation.label") }
-          %>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
+
+      <p class="govuk-body"><%= t(".clarification") %></p>
+
+      <%= f.govuk_email_field :additional_contact_email,
+        width: 20,
+        label: { text: t(".email_address.label") }
+      %>
+      <%= f.govuk_email_field :confirmed_email,
+        width: 20,
+        label: { text: t(".email_address_confirmation.label") }
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/business_type_forms/new.html.erb
+++ b/app/views/flood_risk_engine/business_type_forms/new.html.erb
@@ -13,43 +13,42 @@
         <%= t(".heading") %>
       </h1>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-        <%=
-          f.govuk_collection_radio_buttons :business_type,
-          @business_type_form.business_types,
-          :first,
-          :last,
-          legend: { text: "" },
-          hint: -> do %>
-            <span  class="govuk-!-font-weight-bold govuk-body-m">
-              <%= t(".sub_heading") %>
-            </span>
-            <br/>
-            <%= t(".sub_section_one") %>
-            <details class="govuk-details" data-module="govuk-details">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  <%= t(".summary_heading") %>
-                </span>
-              </summary>
-              <div class="govuk-details__text">
-                <p>
-                  <%= t(".list_heading") %>
-                </p>
-                <ul class="govuk-list govuk-list--bullet">
-                  <% (1..5).each do |number| %>
-                    <li>
-                      <%= t(".list_item_#{number}") %>
 
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-            </details>
-          <% end %>
-        </div>
-      </div>
+    <%=
+      f.govuk_collection_radio_buttons :business_type,
+      @business_type_form.business_types,
+      :first,
+      :last,
+      legend: { text: "" },
+      hint: -> do %>
+        <span  class="govuk-!-font-weight-bold govuk-body-m">
+          <%= t(".sub_heading") %>
+        </span>
+        <br/>
+        <%= t(".sub_section_one") %>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              <%= t(".summary_heading") %>
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p>
+              <%= t(".list_heading") %>
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <% (1..5).each do |number| %>
+                <li>
+                  <%= t(".list_item_#{number}") %>
+
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </details>
+      <% end %>
+
+      <p class="govuk-body"><%= t(".help") %></p>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/flood_risk_engine/check_your_answers_forms/new.html.erb
@@ -1,37 +1,63 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_check_your_answers_forms_path(@check_your_answers_form.token)) %>
 
-<div class="govuk-grid-row">
-  <%= form_for @check_your_answers_form do |f| %>
-    <h1 class="govuk-heading-l">
-      <%= t(".heading") %>
-    </h1>
-    <h2 class="govuk-heading-m">
-      <%= t(".table_heading") %>
-    </h2>
-    <span class="govuk-visually-hidden"><%= t(".table_summary") %></span>
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-      <% @check_your_answers_form.rows.each do |row| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= row[:title] %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= row[:value] %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <% if row[:change_url].present? %>
-              <%= link_to(row[:change_url]) do %>
-                <%= t(".change_link")%>
-                <span class="govuk-visually-hidden">
-                  <%= row[:change_link_suffix] %>
-                </span>
-              <% end %>
-            <% end %>
-          </dd>
-        </div>
-      <% end %>
-    </dl>
+<%= form_for @check_your_answers_form do |f| %>
+  <h1 class="govuk-heading-l">
+    <%= t(".heading") %>
+  </h1>
 
-    <%= f.govuk_submit t(".next_button") %>
-  <% end %>
-</div>
+  <h2 class="govuk-heading-m">
+    <%= t(".registration_table_heading") %>
+  </h2>
+  <span class="govuk-visually-hidden"><%= t(".registration_table_summary") %></span>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% @check_your_answers_form.registration_rows.each do |row| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= row[:title] %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= row[:value] %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <% if row[:change_url].present? %>
+            <%= link_to(row[:change_url]) do %>
+              <%= t(".change_link")%>
+              <span class="govuk-visually-hidden">
+                <%= row[:change_link_suffix] %>
+              </span>
+            <% end %>
+          <% end %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+
+  <h2 class="govuk-heading-m">
+    <%= t(".contact_table_heading") %>
+  </h2>
+  <span class="govuk-visually-hidden"><%= t(".contact_table_summary") %></span>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% @check_your_answers_form.contact_rows.each do |row| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= row[:title] %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= row[:value] %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <% if row[:change_url].present? %>
+            <%= link_to(row[:change_url]) do %>
+              <%= t(".change_link")%>
+              <span class="govuk-visually-hidden">
+                <%= row[:change_link_suffix] %>
+              </span>
+            <% end %>
+          <% end %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+
+  <%= f.govuk_submit t(".next_button") %>
+<% end %>

--- a/app/views/flood_risk_engine/company_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_name_forms/new.html.erb
@@ -9,19 +9,15 @@
         <%= t(".legend.#{@company_name_form.business_type}") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= f.govuk_text_field :company_name,
-            label: {
-              text: t(".heading.#{@company_name_form.business_type}"),
-              tag: "h1",
-              size: "l"
-            },
-            width: 20,
-            hint: { text: t(".hint.#{@company_name_form.business_type}") }
-          %>
-        </div>
-      </div>
+      <%= f.govuk_text_field :company_name,
+        label: {
+          text: t(".heading.#{@company_name_form.business_type}"),
+          tag: "h1",
+          size: "l"
+        },
+        width: 20,
+        hint: { text: t(".hint.#{@company_name_form.business_type}") }
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/company_number_forms/new.html.erb
+++ b/app/views/flood_risk_engine/company_number_forms/new.html.erb
@@ -9,24 +9,20 @@
         <%= t(".legend.#{@company_number_form.business_type}") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= f.govuk_text_field :company_number,
-            label: {
-              text: t(".heading.#{@company_number_form.business_type}"),
-              tag: "h1",
-              size: "l"
-            },
-            width: 5,
-            hint: -> do %>
-              <span class="govuk-body-m">
-                <%= t(".label.#{@company_number_form.business_type}") %>
-              </span>
-              <br/>
-              <%= t(".hint.#{@company_number_form.business_type}") %>
-          <% end %>
-        </div>
-      </div>
+      <%= f.govuk_text_field :company_number,
+        label: {
+          text: t(".heading.#{@company_number_form.business_type}"),
+          tag: "h1",
+          size: "l"
+        },
+        width: 5,
+        hint: -> do %>
+          <span class="govuk-body-m">
+            <%= t(".label.#{@company_number_form.business_type}") %>
+          </span>
+          <br/>
+          <%= t(".hint.#{@company_number_form.business_type}") %>
+      <% end %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
+++ b/app/views/flood_risk_engine/confirm_exemption_forms/new.html.erb
@@ -1,51 +1,47 @@
 <%= render("flood_risk_engine/shared/back", back_path: back_confirm_exemption_forms_path(@confirm_exemption_form.token)) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_for @confirm_exemption_form do |f| %>
-      <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
+<%= form_for @confirm_exemption_form do |f| %>
+  <%= render partial: "flood_risk_engine/shared/error_summary", locals: { f: f } %>
 
-      <span class="govuk-visually-hidden"><%= t('.table_summary') %></span>
+  <span class="govuk-visually-hidden"><%= t('.table_summary') %></span>
 
-      <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--l">
-          <%= t(".heading") %>
-        </caption>
-        <tbody class="govuk-table__body">
-          <% @confirm_exemption_form.transient_registration.exemptions.each do |exemption| %>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">
-              <p><%= exemption.summary %></p>
-            </th>
-            <th scope="row" class="govuk-table__header">
-              <p><%= exemption.code %></p>
-            </th>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
-              <p>
-                <%=
-                  link_to(
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--l">
+      <%= t(".heading") %>
+    </caption>
+    <tbody class="govuk-table__body">
+      <% @confirm_exemption_form.transient_registration.exemptions.each do |exemption| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">
+          <p><%= exemption.summary %></p>
+        </th>
+        <th scope="row" class="govuk-table__header">
+          <p><%= exemption.code %></p>
+        </th>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <p>
+            <%=
+              link_to(
+                t(
+                  ".remove_link.text",
+                  hidden: content_tag(
+                    'span',
                     t(
-                      ".remove_link.text",
-                      hidden: content_tag(
-                        'span',
-                        t(
-                          ".remove_link.hidden",
-                          code: exemption.code
-                        ),
-                        class: "govuk-visually-hidden"
-                      )
-                    ).html_safe,
-                  back_confirm_exemption_forms_path(@confirm_exemption_form.token)
-                )
-                %>
-              </p>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
+                      ".remove_link.hidden",
+                      code: exemption.code
+                    ),
+                    class: "govuk-visually-hidden"
+                  )
+                ).html_safe,
+              back_confirm_exemption_forms_path(@confirm_exemption_form.token)
+            )
+            %>
+          </p>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-      <%= f.govuk_submit t(".next_button") %>
-    <% end %>
-  </div>
-</div>
+  <%= f.govuk_submit t(".next_button") %>
+<% end %>

--- a/app/views/flood_risk_engine/contact_email_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_email_forms/new.html.erb
@@ -9,24 +9,20 @@
         <%= t(".legend") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">
-            <%= t(".heading") %>
-          </h1>
-          <%= f.govuk_email_field :contact_email,
-            width: 20,
-            label: {
-              text: t(".label")
-            },
-            hint: { text: t(".form_hint") }
-          %>
-          <%= f.govuk_email_field :confirmed_email,
-            width: 20,
-            label: {  text: t(".label1") }
-          %>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
+      <%= f.govuk_email_field :contact_email,
+        width: 20,
+        label: {
+          text: t(".label")
+        },
+        hint: { text: t(".form_hint") }
+      %>
+      <%= f.govuk_email_field :confirmed_email,
+        width: 20,
+        label: {  text: t(".label1") }
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/contact_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_name_forms/new.html.erb
@@ -9,22 +9,21 @@
         <%= t(".legend") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">
-            <%= t(".heading") %>
-          </h1>
-          <%= f.govuk_text_field :contact_name,
-            width: 20,
-            label: { text: t(".label") },
-            hint: { text: t(".form_hint_1") }
-          %>
-          <%= f.govuk_text_field :contact_position,
-            width: 20,
-            label: { text: t(".label1") }
-          %>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
+
+      <p class="govuk-body"><%= t(".para_text") %></p>
+
+      <%= f.govuk_text_field :contact_name,
+        width: 20,
+        label: { text: t(".label") },
+        hint: { text: t(".form_hint_1") }
+      %>
+      <%= f.govuk_text_field :contact_position,
+        width: 20,
+        label: { text: t(".label1") }
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_phone_forms/new.html.erb
@@ -9,18 +9,14 @@
         <%= t(".legend") %>
       </span>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">
-            <%= t(".heading") %>
-          </h1>
-          <%= f.govuk_phone_field :contact_phone,
-            width: 10,
-            label: { text: t(".form_label") },
-            hint: { text: t(".form_hint") }
-          %>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l">
+        <%= t(".heading") %>
+      </h1>
+      <%= f.govuk_phone_field :contact_phone,
+        width: 10,
+        label: { text: t(".form_label") },
+        hint: { text: t(".form_hint") }
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/app/views/flood_risk_engine/shared/_error_summary.html.erb
+++ b/app/views/flood_risk_engine/shared/_error_summary.html.erb
@@ -1,5 +1,1 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= f.govuk_error_summary %>
-  </div>
-</div>
+<%= f.govuk_error_summary %>

--- a/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
@@ -13,82 +13,73 @@
         <%= t(".heading") %>
       </h1>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= f.govuk_text_field :temp_grid_reference,
-            label: {
-              text: t(".grid_reference.form_label"),
-              size: "s"
-            },
-            width: "one-third",
-            hint: {
-              text:
-                [
-                  t(".grid_reference.example_hint"),
-                  t(".grid_reference.clarification_hint")
-                ].join("<br/>").html_safe
-            }
-          %>
+      <%= f.govuk_text_field :temp_grid_reference,
+        label: {
+          text: t(".grid_reference.form_label"),
+          size: "s"
+        },
+        width: "one-third",
+        hint: {
+          text:
+            [
+              t(".grid_reference.example_hint"),
+              t(".grid_reference.clarification_hint")
+            ].join("<br/>").html_safe
+        }
+      %>
 
-          <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">
-                <%= t(".details.summary") %>
-              </span>
-            </summary>
-            <div class="govuk-details__text">
-              <p>
-                <%=
-                  t(".details.tool_text",
-                    link: link_to( t(".details.tool_link"), "http://gridreferencefinder.com/",
-                    rel: "external",
-                    target: "_blank")
-                  ).html_safe
-                %>
-              </p>
-              <ol class="govuk-list govuk-list--number">
-                <li><%= t(".details.bullet1") %></li>
-                <li><%= t(".details.bullet2") %></li>
-                <li><%= t(".details.bullet3") %></li>
-              </ol>
-            </div>
-          </details>
-
-          <% if @site_grid_reference_form.require_dredging_length? %>
-            <%= f.govuk_number_field :dredging_length,
-              label: {
-                text: t(".dredging_length.form_label"),
-                size: "s"
-              },
-              width: 5,
-              suffix_text: t(".dredging_length.units"),
-            hint: {
-                text:
-                  [
-                    t(".dredging_length.clarification_hint"),
-                    t(".dredging_length.units")
-                  ].join("<br/>").html_safe
-              }
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= t(".details.summary") %>
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>
+            <%=
+              t(".details.tool_text",
+                link: link_to( t(".details.tool_link"), "http://gridreferencefinder.com/",
+                rel: "external",
+                target: "_blank")
+              ).html_safe
             %>
-          <% end %>
+          </p>
+          <ol class="govuk-list govuk-list--number">
+            <li><%= t(".details.bullet1") %></li>
+            <li><%= t(".details.bullet2") %></li>
+            <li><%= t(".details.bullet3") %></li>
+          </ol>
         </div>
-      </div>
+      </details>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <%= f.govuk_text_area :temp_site_description,
-            label: {
-              text: t(".description.form_label"),
-              size: "s"
-            },
-          hint: {
-              text: t(".description.clarification_hint")
-            },
-            max_chars: 500
-          %>
-        </div>
-      </div>
+      <% if @site_grid_reference_form.require_dredging_length? %>
+        <%= f.govuk_number_field :dredging_length,
+          label: {
+            text: t(".dredging_length.form_label"),
+            size: "s"
+          },
+          width: 5,
+          suffix_text: t(".dredging_length.units"),
+        hint: {
+            text:
+              [
+                t(".dredging_length.clarification_hint"),
+                t(".dredging_length.units")
+              ].join("<br/>").html_safe
+          }
+        %>
+      <% end %>
 
+      <%= f.govuk_text_area :temp_site_description,
+        label: {
+          text: t(".description.form_label"),
+          size: "s"
+        },
+      hint: {
+          text: t(".description.clarification_hint")
+        },
+        max_chars: 500
+      %>
 
       <%= f.govuk_submit t(".next_button") %>
     <% end %>

--- a/config/locales/flood_risk_engine/business_type_forms.en.yml
+++ b/config/locales/flood_risk_engine/business_type_forms.en.yml
@@ -17,14 +17,15 @@ en:
         list_item_4: make financial decisions that affect the activity
         list_item_5: take action to control the activity in an emergency
         options:
-          sole_trader: "Sole trader"
-          limited_company: "Limited company"
+          sole_trader: "Individual (eg a householder)"
+          limited_company: "Limited company (eg a registered company or plc)"
           partnership: "Partnership"
           limited_liability_partnership: "Limited liability partnership"
-          local_authority: "Local authority"
-          charity: "Charity"
-        next_button: "Submit"
+          local_authority: "Local authority or public body"
+          charity: "Other organisation (eg a trust, charity or club)"
+        help: "If you're not sure, please call our helpline on 03708 506 506 to get advice about who might be the organisation or person responsible for your activity."
+        next_button: "Continue"
   defra_ruby:
     validators:
       BusinessTypeValidator:
-        inclusion: "You must answer this question"
+        inclusion: "Select the type of organisation"

--- a/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
+++ b/config/locales/flood_risk_engine/check_your_answers_forms.en.yml
@@ -4,15 +4,17 @@ en:
       new:
         heading: Check your answers before completing this registration
         subheading: We’ll send a copy of these details in the confirmation email.
-        table_heading: Registration details
-        table_summary: "The information you've given us"
+        registration_table_heading: Registration details
+        registration_table_summary: "The information you've given us about the registration"
+        contact_table_heading: Contact details
+        contact_table_summary: "The information you've given us about the contact"
         change_link: Change
         rows:
-          organisation_registration_number:
+          company_number:
             title: Company registration number
             accessible_change_link_suffix: company registration number
           business_type:
-            title: Customer type
+            title: Organisation type
             value:
               sole_trader: "Sole trader"
               limited_company: "Limited company"
@@ -20,13 +22,13 @@ en:
               limited_liability_partnership: "Limited liability partnership"
               local_authority: "Local authority"
               charity: "Charity"
-            accessible_change_link_suffix: customer type
+            accessible_change_link_suffix: organisation type
           grid_reference:
             title: Grid reference
             accessible_change_link_suffix: grid reference
           exemption:
-            title: Exemption %{code}
-            accessible_change_link_suffix: exemption %{code}
+            title: Exemption type
+            accessible_change_link_suffix: exemption
           site_description:
             title: Site description
             accessible_change_link_suffix: site description
@@ -37,24 +39,27 @@ en:
               other: "%{dredging_length} metres"
             accessible_change_link_suffix: dredging length
           company_name:
-            title: Responsible for activity (‘operator’)
-            accessible_change_link_suffix: operator
+            title: Operator name
+            accessible_change_link_suffix: operator name
           company_address:
-            title: Their address
-            accessible_change_link_suffix: their address
+            title: Operator address
+            accessible_change_link_suffix: operator address
           contact_name:
-            title: Who we will contact
+            title: Contact name
             value:
               position: "%{contact_name} (%{contact_position})"
               no_position: "%{contact_name}"
-            accessible_change_link_suffix: who we will contact
+            accessible_change_link_suffix: contact name
           contact_phone:
-            title: Telephone
+            title: Contact telephone
             accessible_change_link_suffix: telephone
           contact_email:
-            title: Email
+            title: Contact email
             accessible_change_link_suffix: email
+          additional_contact_email:
+            title: Additional contact email
+            accessible_change_link_suffix: additional email
           partner:
             title: Details of responsible partner
             accessible_change_link_suffix: responsible partner
-        next_button: "Submit"
+        next_button: "Continue"

--- a/config/locales/flood_risk_engine/company_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_name_forms.en.yml
@@ -26,7 +26,7 @@ en:
           limited_liability_partnership: "Enter the registered name of the partnership"
           local_authority: "For example, Bristol City Council"
           sole_trader: "For example, Jane Smith"
-        next_button: "Submit"
+        next_button: "Continue"
   activemodel:
       errors:
         models:

--- a/config/locales/flood_risk_engine/company_number_forms.en.yml
+++ b/config/locales/flood_risk_engine/company_number_forms.en.yml
@@ -14,7 +14,7 @@ en:
         legend:
           limited_company: Registration number of the company
           limited_liability_partnership: Registration number of the partnership
-        next_button: "Submit"
+        next_button: "Continue"
   activemodel:
       errors:
         models:

--- a/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/confirm_exemption_forms.en.yml
@@ -8,4 +8,4 @@ en:
           text: Change %{hidden}
           hidden: exemption %{code}
         table_summary: Exemption and link to change it
-        next_button: "Submit"
+        next_button: Save and continue

--- a/config/locales/flood_risk_engine/contact_email_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_email_forms.en.yml
@@ -15,7 +15,7 @@ en:
           email_address_confirmation:
             blank: Enter your email address again to confirm it
             format: "The email addresses you’ve entered don’t match"
-        next_button: "Submit"
+        next_button: "Continue"
   activemodel:
       errors:
         models:

--- a/config/locales/flood_risk_engine/contact_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_name_forms.en.yml
@@ -11,7 +11,7 @@ en:
         para_text: We may need to contact someone to check details of the activities or arrange a site visit.
           We’ll send a confirmation of your registration to this person.
           You can add another email address later if someone else needs a copy of the confirmation.
-        next_button: "Submit"
+        next_button: "Continue"
   activemodel:
     errors:
       models:

--- a/config/locales/flood_risk_engine/contact_phone_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_phone_forms.en.yml
@@ -10,7 +10,7 @@ en:
           telephone_number:
             invalid: Enter a valid telephone number
             blank: Enter a telephone number
-        next_button: "Submit"
+        next_button: "Continue"
   defra_ruby:
     validators:
       PhoneNumberValidator:

--- a/config/locales/flood_risk_engine/exemption_forms.en.yml
+++ b/config/locales/flood_risk_engine/exemption_forms.en.yml
@@ -7,7 +7,7 @@ en:
           text_1: You can only register one exemption at a time.
           text_2: If you need more than one, please make a new registration for each.
           link: Exempt flood risk activities guidance
-        next_button: "Submit"
+        next_button: Continue
   activemodel:
     errors:
       models:

--- a/config/locales/flood_risk_engine/partner_address_lookup_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_address_lookup_forms.en.yml
@@ -2,7 +2,7 @@ en:
   flood_risk_engine:
     partner_address_lookup_forms:
       new:
-        heading: Select partner address
+        heading: Select the address of this partner
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"

--- a/config/locales/flood_risk_engine/partner_address_manual_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_address_manual_forms.en.yml
@@ -2,7 +2,7 @@ en:
   flood_risk_engine:
     partner_address_manual_forms:
       new:
-        heading: What's the partner address?
+        heading: Enter the address of this partner
         os_places_error_heading: Our address finder is not working
         os_places_error_text: Please enter the address below.
         preset_postcode_label: Postcode

--- a/config/locales/flood_risk_engine/partner_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_name_forms.en.yml
@@ -3,14 +3,14 @@ en:
     partner_name_forms:
       new:
         heading: "What are the names of all the business partners?"
-        description_1: "Add another business partner"
+        description_1: "We need to know the name and home address of all business partners."
         full_name: "Full name"
         form_hint: "For example, Jane Smith"
         next_button: Continue
   activemodel:
     errors:
       models:
-        waste_carriers_engine/main_people_form:
+        flood_risk_engine/partner_name_form:
           attributes:
             full_name:
               blank: "Enter a full name"

--- a/config/locales/flood_risk_engine/partner_overview_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_overview_forms.en.yml
@@ -8,4 +8,4 @@ en:
         remove: Remove
         add_another: Add another partner
         confirm_delete: Are you sure you wish to remove %{name}?
-        next_button: "Next"
+        next_button: "Continue"

--- a/config/locales/flood_risk_engine/partner_postcode_forms.en.yml
+++ b/config/locales/flood_risk_engine/partner_postcode_forms.en.yml
@@ -2,7 +2,7 @@ en:
   flood_risk_engine:
     partner_postcode_forms:
       new:
-        heading: Find the address of the partner
+        heading: Find the address of this partner
         temp_partner_postcode_label: Enter a UK postcode
         temp_partner_postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix

--- a/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
+++ b/config/locales/flood_risk_engine/site_grid_reference_forms.en.yml
@@ -37,4 +37,21 @@ en:
           dredging_length:
             blank: Enter the approximate length of dredging
             numeric: The length of dredging must be a number between %{min} and %{max}
-        next_button: "Submit"
+        next_button: Continue
+  defra_ruby:
+    validators:
+      GridReferenceValidator:
+        blank: Enter a National Grid reference
+        invalid_format: The grid reference should have 2 letters and 10 digits
+        invalid: The grid reference is not a valid coordinate
+  activemodel:
+    errors:
+      models:
+        flood_risk_engine/site_grid_reference_form:
+          attributes:
+            temp_site_description:
+              too_long: The site name or description must be no longer than 500 characters
+              blank: Enter a site name or description
+            dredging_length:
+              blank: Enter the approximate length of dredging
+              numeric: The length of dredging must be a number between 1 and 1500

--- a/spec/factories/new_registrations_factory.rb
+++ b/spec/factories/new_registrations_factory.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
     end
 
     trait :has_required_data do
-      additional_contact_email { Faker::Name.name }
       business_type { "soleTrader" }
       company_name { Faker::Company.name }
       contact_email { generate(:random_email) }

--- a/spec/presenters/flood_risk_engine/check_your_answers_presenter_spec.rb
+++ b/spec/presenters/flood_risk_engine/check_your_answers_presenter_spec.rb
@@ -11,120 +11,151 @@ module FloodRiskEngine
       described_class.new(new_registration)
     end
 
-    let(:expected_data) do
-      [
-        {
-          title: "Exemption #{new_registration.exemptions.first.code}",
-          value: new_registration.exemptions.first.summary
-        },
-        {
-          title: "Grid reference",
-          value: new_registration.temp_grid_reference
-        },
-        {
-          title: "Site description",
-          value: new_registration.temp_site_description
-        },
-        {
-          title: "Customer type",
-          value: "Limited company"
-        },
-        {
-          title: "Responsible for activity (‘operator’)",
-          value: new_registration.company_name
-        },
-        {
-          title: "Their address",
-          value: [
-            new_registration.try(:company_address).try(:organisation),
-            new_registration.try(:company_address).try(:premises),
-            new_registration.try(:company_address).try(:street_address),
-            new_registration.try(:company_address).try(:locality),
-            new_registration.try(:company_address).try(:city),
-            new_registration.try(:company_address).try(:postcode)
+    describe "#registration_rows" do
+      let(:expected_data) do
+        [
+          {
+            title: "Exemption type",
+            value: "#{new_registration.exemptions.first.code} #{new_registration.exemptions.first.summary}"
+          },
+          {
+            title: "Grid reference",
+            value: new_registration.temp_grid_reference
+          },
+          {
+            title: "Site description",
+            value: new_registration.temp_site_description
+          },
+          {
+            title: "Organisation type",
+            value: "Limited company"
+          },
+          {
+            title: "Company registration number",
+            value: new_registration.company_number
+          },
+          {
+            title: "Operator name",
+            value: new_registration.company_name
+          },
+          {
+            title: "Operator address",
+            value: [
+              new_registration.try(:company_address).try(:organisation),
+              new_registration.try(:company_address).try(:premises),
+              new_registration.try(:company_address).try(:street_address),
+              new_registration.try(:company_address).try(:locality),
+              new_registration.try(:company_address).try(:city),
+              new_registration.try(:company_address).try(:postcode)
+            ].join(", ")
+          }
+        ]
+      end
+
+      it "returns the properly-formatted data" do
+        expect(subject.registration_rows).to eq(expected_data)
+      end
+
+      context "when the registration is a partnership" do
+        let(:new_registration) do
+          build(:new_registration,
+                :has_required_data_for_partnership)
+        end
+
+        before do
+          first_partner = new_registration.transient_people.first
+          first_partner_text = [
+            first_partner.full_name,
+            first_partner.transient_address.organisation,
+            first_partner.transient_address.premises,
+            first_partner.transient_address.street_address,
+            first_partner.transient_address.locality,
+            first_partner.transient_address.city,
+            first_partner.transient_address.postcode
           ].join(", ")
-        },
-        {
-          title: "Who we will contact",
-          value: "#{new_registration.contact_name} (#{new_registration.contact_position})"
-        },
-        {
-          title: "Telephone",
-          value: new_registration.contact_phone
-        },
-        {
-          title: "Email",
-          value: new_registration.contact_email
-        }
-      ]
-    end
 
-    it "returns the properly-formatted data" do
-      expect(subject.rows).to eq(expected_data)
-    end
+          second_partner = new_registration.transient_people.last
+          second_partner_text = [
+            second_partner.full_name,
+            second_partner.transient_address.organisation,
+            second_partner.transient_address.premises,
+            second_partner.transient_address.street_address,
+            second_partner.transient_address.locality,
+            second_partner.transient_address.city,
+            second_partner.transient_address.postcode
+          ].join(", ")
 
-    context "when the registration is a partnership" do
-      let(:new_registration) do
-        build(:new_registration,
-              :has_required_data_for_partnership)
+          expected_data[3][:value] = "Partnership"
+          # Remove company number, name and address
+          expected_data.delete_at(4)
+          expected_data.delete_at(4)
+          expected_data.delete_at(4)
+          # Replace with partnership data
+          expected_data.insert(4, title: "Details of responsible partner", value: first_partner_text)
+          expected_data.insert(5, title: "Details of responsible partner", value: second_partner_text)
+        end
+
+        it "returns the properly-formatted data" do
+          expect(subject.registration_rows).to eq(expected_data)
+        end
       end
 
-      before do
-        first_partner = new_registration.transient_people.first
-        first_partner_text = [
-          first_partner.full_name,
-          first_partner.transient_address.organisation,
-          first_partner.transient_address.premises,
-          first_partner.transient_address.street_address,
-          first_partner.transient_address.locality,
-          first_partner.transient_address.city,
-          first_partner.transient_address.postcode
-        ].join(", ")
+      context "when the registration has a FRA23 exemption" do
+        before do
+          new_registration.exemptions = [build(:exemption, code: "FRA23")]
+          new_registration.dredging_length = 5
 
-        second_partner = new_registration.transient_people.last
-        second_partner_text = [
-          second_partner.full_name,
-          second_partner.transient_address.organisation,
-          second_partner.transient_address.premises,
-          second_partner.transient_address.street_address,
-          second_partner.transient_address.locality,
-          second_partner.transient_address.city,
-          second_partner.transient_address.postcode
-        ].join(", ")
+          expected_data.insert(3, title: "Dredging length", value: "#{new_registration.dredging_length} metres")
+        end
 
-        expected_data[3][:value] = "Partnership"
-        expected_data.delete_at(4)
-        expected_data.delete_at(4)
-        expected_data.insert(4, title: "Details of responsible partner", value: first_partner_text)
-        expected_data.insert(5, title: "Details of responsible partner", value: second_partner_text)
+        it "returns the properly-formatted data" do
+          expect(subject.registration_rows).to eq(expected_data)
+        end
+      end
+    end
+
+    describe "#contact_rows" do
+      let(:expected_data) do
+        [
+          {
+            title: "Contact name",
+            value: "#{new_registration.contact_name} (#{new_registration.contact_position})"
+          },
+          {
+            title: "Contact telephone",
+            value: new_registration.contact_phone
+          },
+          {
+            title: "Contact email",
+            value: new_registration.contact_email
+          }
+        ]
       end
 
       it "returns the properly-formatted data" do
-        expect(subject.rows).to eq(expected_data)
-      end
-    end
-
-    context "when the registration has a FRA23 exemption" do
-      before do
-        new_registration.exemptions = [build(:exemption, code: "FRA23")]
-        new_registration.dredging_length = 5
-
-        expected_data.insert(3, title: "Dredging length", value: "#{new_registration.dredging_length} metres")
+        expect(subject.contact_rows).to eq(expected_data)
       end
 
-      it "returns the properly-formatted data" do
-        expect(subject.rows).to eq(expected_data)
-      end
-    end
+      context "when the registration has no contact position" do
+        before do
+          new_registration.contact_position = nil
+          expected_data[0][:value] = new_registration.contact_name
+        end
 
-    context "when the registration has no contact position" do
-      before do
-        new_registration.contact_position = nil
-        expected_data[6][:value] = new_registration.contact_name
+        it "returns the properly-formatted data" do
+          expect(subject.contact_rows).to eq(expected_data)
+        end
       end
 
-      it "returns the properly-formatted data" do
-        expect(subject.rows).to eq(expected_data)
+      context "when the registration has an additional contact" do
+        before do
+          new_registration.additional_contact_email = "additional@example.com"
+          expected_data[3] = { title: "Additional contact email", value: "additional@example.com" }
+        end
+
+        it "returns the properly-formatted data" do
+          expect(subject.contact_rows).to eq(expected_data)
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1460
https://eaflood.atlassian.net/browse/RUBY-1461
https://eaflood.atlassian.net/browse/RUBY-1462
https://eaflood.atlassian.net/browse/RUBY-1463
https://eaflood.atlassian.net/browse/RUBY-1464

This PR contains a number of small fixes following another review of the wireframes before design review.

Notably this includes adding additional info to the 'check your answers' page, and fixing a recurring error where design system divs were being repeated unnecessarily, causing content to be squashed.