### PR TITLE
Turn NewRegistrations into Enrollments on submission

### DIFF
--- a/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/flood_risk_engine/registration_complete_forms_controller.rb
@@ -6,7 +6,9 @@ module FloodRiskEngine
     include CannotGoBackForm
 
     def new
-      super(RegistrationCompleteForm, "registration_complete_form")
+      return unless super(RegistrationCompleteForm, "registration_complete_form")
+
+      @enrollment = RegistrationCompletionService.run(transient_registration: @transient_registration)
     end
   end
 end

--- a/app/forms/flood_risk_engine/registration_complete_form.rb
+++ b/app/forms/flood_risk_engine/registration_complete_form.rb
@@ -2,8 +2,6 @@
 
 module FloodRiskEngine
   class RegistrationCompleteForm < ::FloodRiskEngine::BaseForm
-    delegate :reference_number, to: :transient_registration
-
     def self.can_navigate_flexibly?
       false
     end

--- a/app/models/flood_risk_engine/transient_registration.rb
+++ b/app/models/flood_risk_engine/transient_registration.rb
@@ -6,7 +6,8 @@ module FloodRiskEngine
 
     self.table_name = "transient_registrations"
 
-    has_many :transient_people
+    has_many :transient_people, dependent: :destroy
+
     has_many :transient_registration_exemptions, dependent: :destroy
     has_many :exemptions, through: :transient_registration_exemptions
 

--- a/app/models/flood_risk_engine/transient_registration.rb
+++ b/app/models/flood_risk_engine/transient_registration.rb
@@ -33,9 +33,5 @@ module FloodRiskEngine
     def completed_partners
       transient_people.select { |partner| partner.transient_address.present? }
     end
-
-    def reference_number
-      "TODO"
-    end
   end
 end

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module FloodRiskEngine
+  class RegistrationCompletionService < BaseService
+    def run(transient_registration:)
+      @transient_registration = transient_registration
+      @registration = nil
+
+      @transient_registration.with_lock do
+        # This update is necessary as this will make the `with_lock` prevent race conditions
+        @transient_registration.update(workflow_state: :creating_registration)
+
+        @registration = Enrollment.new
+        # Set attributes and all that
+
+        @registration.save!
+
+        @transient_registration.destroy
+      end
+
+      @registration
+    rescue StandardError => e
+      Airbrake.notify(e, reference: @registration&.reference) if defined?(Airbrake)
+      Rails.logger.error "Completing registration error: #{e}"
+
+      raise e
+    end
+  end
+end

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -20,7 +20,7 @@ module FloodRiskEngine
 
       @registration
     rescue StandardError => e
-      Airbrake.notify(e, reference: @registration&.reference) if defined?(Airbrake)
+      Airbrake.notify(e, reference: @registration&.reference_number) if defined?(Airbrake)
       Rails.logger.error "Completing registration error: #{e}"
 
       raise e

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -18,6 +18,8 @@ module FloodRiskEngine
         @transient_registration.destroy
       end
 
+      update_water_management_area
+
       @registration
     rescue StandardError => e
       Airbrake.notify(e, reference: @registration&.reference_number) if defined?(Airbrake)
@@ -131,6 +133,10 @@ module FloodRiskEngine
       @registration.enrollment_exemptions.each do |ee|
         ee.status = 1
       end
+    end
+
+    def update_water_management_area
+      UpdateWaterManagementAreaJob.perform_later(@registration.exemption_location)
     end
 
     def org_type

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -95,7 +95,13 @@ module FloodRiskEngine
       end
     end
 
-    def add_exemption_location; end
+    def add_exemption_location
+      @registration.exemption_location = Location.new(
+        grid_reference: @transient_registration.temp_grid_reference,
+        description: @transient_registration.temp_site_description,
+        dredging_length: @transient_registration.dredging_length
+      )
+    end
 
     def assign_reference_number; end
 

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -103,7 +103,9 @@ module FloodRiskEngine
       )
     end
 
-    def assign_reference_number; end
+    def assign_reference_number
+      @registration.reference_number = ReferenceNumber.create
+    end
 
     def org_type
       enrollment_org_types = {

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -11,8 +11,7 @@ module FloodRiskEngine
         @transient_registration.update(workflow_state: :creating_registration)
 
         @registration = Enrollment.new
-        # Set attributes and all that
-
+        transfer_data
         @registration.save!
 
         @transient_registration.destroy
@@ -25,5 +24,35 @@ module FloodRiskEngine
 
       raise e
     end
+
+    private
+
+    def transfer_data
+      add_core_data
+
+      add_applicant_contact
+      add_correspondence_contact
+      add_secondary_contact
+      add_organisation
+
+      assign_exemptions
+      assign_reference_number
+    end
+
+    def add_core_data
+      @registration.step = "confirmation"
+    end
+
+    def add_applicant_contact; end
+
+    def add_correspondence_contact; end
+
+    def add_secondary_contact; end
+
+    def add_organisation; end
+
+    def assign_exemptions; end
+
+    def assign_reference_number; end
   end
 end

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -141,7 +141,8 @@ module FloodRiskEngine
     end
 
     def transferable_address_attributes(address)
-      address.attributes.except("address_type",
+      address.attributes.except("id",
+                                "address_type",
                                 "token",
                                 "addressable_id",
                                 "addressable_type",

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -30,7 +30,6 @@ module FloodRiskEngine
     def transfer_data
       add_core_data
 
-      add_applicant_contact
       add_correspondence_contact
       add_secondary_contact
       add_organisation
@@ -43,11 +42,22 @@ module FloodRiskEngine
       @registration.step = "confirmation"
     end
 
-    def add_applicant_contact; end
+    def add_correspondence_contact
+      @registration.correspondence_contact = Contact.new(
+        full_name: @transient_registration.contact_name,
+        email_address: @transient_registration.contact_email,
+        telephone_number: @transient_registration.contact_phone,
+        position: @transient_registration.contact_position
+      )
+    end
 
-    def add_correspondence_contact; end
+    def add_secondary_contact
+      return unless @transient_registration.additional_contact_email.present?
 
-    def add_secondary_contact; end
+      @registration.secondary_contact = Contact.new(
+        email_address: @transient_registration.additional_contact_email
+      )
+    end
 
     def add_organisation; end
 

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -8,7 +8,6 @@ module FloodRiskEngine
       @registration = nil
 
       @transient_registration.with_lock do
-        # This update is necessary as this will make the `with_lock` prevent race conditions
         @transient_registration.update(workflow_state: :creating_registration)
 
         @registration = Enrollment.new

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -32,9 +32,16 @@ module FloodRiskEngine
 
       add_correspondence_contact
       add_secondary_contact
-      add_organisation
+
+      if @transient_registration.partnership?
+        add_partnership_organisation
+      else
+        add_organisation
+      end
 
       assign_exemption
+      add_exemption_location
+
       assign_reference_number
     end
 
@@ -59,11 +66,27 @@ module FloodRiskEngine
       )
     end
 
+    def add_partnership_organisation; end
+
     def add_organisation
       @registration.organisation = Organisation.new(
         name: @transient_registration.company_name,
         org_type: org_type
       )
+
+      add_address
+    end
+
+    def add_address
+      address = @transient_registration.company_address
+      transferable_attributes = address.attributes.except("address_type",
+                                                          "token",
+                                                          "addressable_id",
+                                                          "addressable_type",
+                                                          "created_at",
+                                                          "updated_at")
+
+      @registration.organisation.primary_address = Address.new(transferable_attributes)
     end
 
     def assign_exemption
@@ -71,6 +94,8 @@ module FloodRiskEngine
         @registration.exemptions << exemption
       end
     end
+
+    def add_exemption_location; end
 
     def assign_reference_number; end
 

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -34,7 +34,7 @@ module FloodRiskEngine
       add_secondary_contact
       add_organisation
 
-      assign_exemptions
+      assign_exemption
       assign_reference_number
     end
 
@@ -59,10 +59,34 @@ module FloodRiskEngine
       )
     end
 
-    def add_organisation; end
+    def add_organisation
+      @registration.organisation = Organisation.new(
+        name: @transient_registration.company_name,
+        org_type: org_type
+      )
+    end
 
-    def assign_exemptions; end
+    def assign_exemption
+      @transient_registration.exemptions.each do |exemption|
+        @registration.exemptions << exemption
+      end
+    end
 
     def assign_reference_number; end
+
+    def org_type
+      enrollment_org_types = {
+        localAuthority: 0,
+        limitedCompany: 1,
+        limitedLiabilityPartnership: 2,
+        soleTrader: 3,
+        partnership: 4,
+        charity: 5
+      }
+
+      transient_type = @transient_registration.business_type.to_sym
+
+      enrollment_org_types[transient_type]
+    end
   end
 end

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -64,8 +64,6 @@ module FloodRiskEngine
     end
 
     def add_secondary_contact
-      return unless @transient_registration.additional_contact_email.present?
-
       @registration.secondary_contact = Contact.new(
         email_address: @transient_registration.additional_contact_email
       )

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -19,6 +19,7 @@ module FloodRiskEngine
       end
 
       update_water_management_area
+      send_confirmation_email
 
       @registration
     rescue StandardError => e
@@ -135,6 +136,10 @@ module FloodRiskEngine
 
     def update_water_management_area
       UpdateWaterManagementAreaJob.perform_later(@registration.exemption_location)
+    end
+
+    def send_confirmation_email
+      SendEnrollmentSubmittedEmail.new(@registration).call
     end
 
     def org_type

--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -44,10 +44,12 @@ module FloodRiskEngine
       add_exemption_location
 
       assign_reference_number
+      update_status
     end
 
     def add_core_data
       @registration.step = "confirmation"
+      @registration.submitted_at = Time.zone.now
     end
 
     def add_correspondence_contact
@@ -123,6 +125,12 @@ module FloodRiskEngine
 
     def assign_reference_number
       @registration.reference_number = ReferenceNumber.create
+    end
+
+    def update_status
+      @registration.enrollment_exemptions.each do |ee|
+        ee.status = 1
+      end
     end
 
     def org_type

--- a/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
+++ b/app/views/flood_risk_engine/registration_complete_forms/new.html.erb
@@ -12,7 +12,7 @@
           <div class="govuk-panel__body">
             <%= t(".reference") %><br />
             <strong>
-              <span id="reg_identifier"><%= @registration_complete_form.reference_number %></span>
+              <span id="reg_identifier"><%= @enrollment.reference_number %></span>
             </strong>
           </div>
         </div>

--- a/spec/factories/new_registrations_factory.rb
+++ b/spec/factories/new_registrations_factory.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       contact_name { Faker::Name.name }
       contact_phone { Faker::PhoneNumber.phone_number }
       contact_position { Faker::Company.profession }
-      temp_grid_reference { Faker::Number.number(digits: 10) }
+      temp_grid_reference { "ST 58132 72695" }
       temp_site_description { Faker::Lorem.sentence }
 
       exemptions { [build(:exemption)] }

--- a/spec/requests/flood_risk_engine/registration_complete_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/registration_complete_forms_spec.rb
@@ -16,6 +16,7 @@ module FloodRiskEngine
       context "when a valid new registration exists" do
         let(:transient_registration) do
           create(:new_registration,
+                 :has_required_data_for_limited_company,
                  workflow_state: "registration_complete_form")
         end
 

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -36,6 +36,17 @@ module FloodRiskEngine
         expect(enrollment.correspondence_contact.attributes).to include(correspondence_contact_attributes)
       end
 
+      it "assigns the correct organisation to the new enrollment" do
+        organisation_attributes = {
+          "name" => new_registration.company_name,
+          "org_type" => "limited_company"
+        }
+
+        subject
+
+        expect(enrollment.organisation.attributes).to include(organisation_attributes)
+      end
+
       context "when an additional contact email was given" do
         before { new_registration.update(additional_contact_email: "test@example.com") }
 
@@ -48,6 +59,15 @@ module FloodRiskEngine
 
           expect(enrollment.secondary_contact.attributes).to include(secondary_contact_attributes)
         end
+      end
+
+      it "assigns the correct exemption and enrollment_exemption to the new enrollment" do
+        expected_exemption = new_registration.exemptions.first
+
+        subject
+
+        expect(enrollment.exemptions.first).to eq(expected_exemption)
+        expect(enrollment.enrollment_exemptions.first.exemption_id).to eq(expected_exemption.id)
       end
 
       it "deletes the old transient registration" do

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -85,6 +85,18 @@ module FloodRiskEngine
         expect(enrollment.organisation.primary_address.attributes).to include(expected_address_data)
       end
 
+      it "assigns the correct site location to the new enrollment" do
+        location_attributes = {
+          "grid_reference" => new_registration.temp_grid_reference,
+          "description" => new_registration.temp_site_description,
+          "dredging_length" => new_registration.dredging_length
+        }
+
+        subject
+
+        expect(enrollment.exemption_location.attributes).to include(location_attributes)
+      end
+
       it "deletes the old transient registration" do
         new_registration.touch # So the object exists to be counted before the service runs
 

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -70,6 +70,21 @@ module FloodRiskEngine
         expect(enrollment.enrollment_exemptions.first.exemption_id).to eq(expected_exemption.id)
       end
 
+      it "assigns the correct address to the new enrollment" do
+        expected_address_data = new_registration.company_address.attributes.except(
+          "address_type",
+          "token",
+          "addressable_id",
+          "addressable_type",
+          "created_at",
+          "updated_at"
+        )
+
+        subject
+
+        expect(enrollment.organisation.primary_address.attributes).to include(expected_address_data)
+      end
+
       it "deletes the old transient registration" do
         new_registration.touch # So the object exists to be counted before the service runs
 

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -10,10 +10,17 @@ module FloodRiskEngine
              workflow_state: "registration_complete_form")
     end
     let(:subject) { described_class.run(transient_registration: new_registration) }
+    let(:enrollment) { Enrollment.last }
 
     describe "#run" do
       it "creates a new enrollment" do
         expect { subject }.to change { Enrollment.count }.by(1)
+      end
+
+      it "assigns the correct data to the new enrollment" do
+        subject
+
+        expect(enrollment.step).to eq("confirmation")
       end
 
       it "deletes the old transient registration" do

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -112,6 +112,12 @@ module FloodRiskEngine
         expect(enrollment.enrollment_exemptions.first.status).to eq("pending")
       end
 
+      it "sends a confirmation email" do
+        expect(SendEnrollmentSubmittedEmail).to receive(:new).with(an_instance_of(Enrollment)).and_call_original
+
+        subject
+      end
+
       it "deletes the old transient registration" do
         new_registration.touch # So the object exists to be counted before the service runs
 

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -51,18 +51,14 @@ module FloodRiskEngine
         expect(enrollment.organisation.attributes).to include(organisation_attributes)
       end
 
-      context "when an additional contact email was given" do
-        before { new_registration.update(additional_contact_email: "test@example.com") }
+      it "assigns the correct secondary contact to the new enrollment" do
+        secondary_contact_attributes = {
+          "email_address" => new_registration.additional_contact_email
+        }
 
-        it "assigns the correct secondary contact to the new enrollment" do
-          secondary_contact_attributes = {
-            "email_address" => new_registration.additional_contact_email
-          }
+        subject
 
-          subject
-
-          expect(enrollment.secondary_contact.attributes).to include(secondary_contact_attributes)
-        end
+        expect(enrollment.secondary_contact.attributes).to include(secondary_contact_attributes)
       end
 
       it "assigns the correct exemption and enrollment_exemption to the new enrollment" do

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -91,6 +91,8 @@ module FloodRiskEngine
       end
 
       it "assigns the correct site location to the new enrollment" do
+        expect(UpdateWaterManagementAreaJob).to receive(:perform_later).with(an_instance_of(Location))
+
         location_attributes = {
           "grid_reference" => new_registration.temp_grid_reference,
           "description" => new_registration.temp_site_description,

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -18,9 +18,13 @@ module FloodRiskEngine
       end
 
       it "assigns the correct data to the new enrollment" do
+        stub_time = Time.new(2000, 1, 1)
+        expect(Time.zone).to receive(:now).at_least(:once).and_return(stub_time)
+
         subject
 
         expect(enrollment.step).to eq("confirmation")
+        expect(enrollment.submitted_at).to eq(stub_time)
       end
 
       it "assigns the correct correspondance contact to the new enrollment" do
@@ -102,6 +106,12 @@ module FloodRiskEngine
         subject
 
         expect(enrollment.reference_number).to eq(ReferenceNumber.last.number)
+      end
+
+      it "assigns the status" do
+        subject
+
+        expect(enrollment.enrollment_exemptions.first.status).to eq("pending")
       end
 
       it "deletes the old transient registration" do

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -23,6 +23,33 @@ module FloodRiskEngine
         expect(enrollment.step).to eq("confirmation")
       end
 
+      it "assigns the correct correspondance contact to the new enrollment" do
+        correspondence_contact_attributes = {
+          "full_name" => new_registration.contact_name,
+          "email_address" => new_registration.contact_email,
+          "telephone_number" => new_registration.contact_phone,
+          "position" => new_registration.contact_position
+        }
+
+        subject
+
+        expect(enrollment.correspondence_contact.attributes).to include(correspondence_contact_attributes)
+      end
+
+      context "when an additional contact email was given" do
+        before { new_registration.update(additional_contact_email: "test@example.com") }
+
+        it "assigns the correct secondary contact to the new enrollment" do
+          secondary_contact_attributes = {
+            "email_address" => new_registration.additional_contact_email
+          }
+
+          subject
+
+          expect(enrollment.secondary_contact.attributes).to include(secondary_contact_attributes)
+        end
+      end
+
       it "deletes the old transient registration" do
         new_registration.touch # So the object exists to be counted before the service runs
 
@@ -40,6 +67,14 @@ module FloodRiskEngine
           expect { subject }.to raise_error(StandardError)
 
           expect(Enrollment.count).to eq(old_count)
+        end
+
+        it "does not create new related objects" do
+          old_count = Contact.count
+
+          expect { subject }.to raise_error(StandardError)
+
+          expect(Contact.count).to eq(old_count)
         end
 
         it "does not delete the old transient registration" do

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -72,6 +72,7 @@ module FloodRiskEngine
 
       it "assigns the correct address to the new enrollment" do
         expected_address_data = new_registration.company_address.attributes.except(
+          "id",
           "address_type",
           "token",
           "addressable_id",
@@ -128,7 +129,7 @@ module FloodRiskEngine
         end
 
         it "assigns the correct partners to the new enrollment" do
-          excluded_address_attributes = %w[address_type token addressable_id addressable_type created_at updated_at]
+          excluded_address_attributes = %w[id address_type token addressable_id addressable_type created_at updated_at]
 
           first_partner = new_registration.transient_people.first
           first_partner_name = first_partner.full_name

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -21,6 +21,29 @@ module FloodRiskEngine
 
         expect { subject }.to change { NewRegistration.count }.by(-1)
       end
+
+      context "when an error occurs" do
+        before do
+          expect(new_registration).to receive(:destroy).and_raise(StandardError)
+        end
+
+        it "does not create a new enrollment" do
+          old_count = Enrollment.count
+
+          expect { subject }.to raise_error(StandardError)
+
+          expect(Enrollment.count).to eq(old_count)
+        end
+
+        it "does not delete the old transient registration" do
+          new_registration.touch # So the object exists to be counted before the service runs
+          old_count = NewRegistration.count
+
+          expect { subject }.to raise_error(StandardError)
+
+          expect(NewRegistration.count).to eq(old_count)
+        end
+      end
     end
   end
 end

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe RegistrationCompletionService do
+    let(:new_registration) do
+      create(:new_registration,
+             :has_required_data_for_limited_company,
+             workflow_state: "registration_complete_form")
+    end
+    let(:subject) { described_class.run(transient_registration: new_registration) }
+
+    describe "#run" do
+      it "creates a new enrollment" do
+        expect { subject }.to change { Enrollment.count }.by(1)
+      end
+
+      it "deletes the old transient registration" do
+        new_registration.touch # So the object exists to be counted before the service runs
+
+        expect { subject }.to change { NewRegistration.count }.by(-1)
+      end
+    end
+  end
+end

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -97,6 +97,12 @@ module FloodRiskEngine
         expect(enrollment.exemption_location.attributes).to include(location_attributes)
       end
 
+      it "assigns the correct reference number" do
+        subject
+
+        expect(enrollment.reference_number).to eq(ReferenceNumber.last.number)
+      end
+
       it "deletes the old transient registration" do
         new_registration.touch # So the object exists to be counted before the service runs
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1474

Once a user submits their application to register, we need to turn the NewRegistration record that has been used for the forms into a proper Enrollment record.

This also means restructuring the data to match the Enrollment schema and its related objects. Once the submission is completed, the new Enrollment should be visible and manageable in the back office as before.

The old temporary NewRegistration record should then be deleted.