### PR TITLE
Don't display metres twice in hint text

### DIFF
--- a/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/flood_risk_engine/site_grid_reference_forms/new.html.erb
@@ -60,13 +60,7 @@
           },
           width: 5,
           suffix_text: t(".dredging_length.units"),
-        hint: {
-            text:
-              [
-                t(".dredging_length.clarification_hint"),
-                t(".dredging_length.units")
-              ].join("<br/>").html_safe
-          }
+        hint: { text: t(".dredging_length.clarification_hint") }
         %>
       <% end %>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1461

This fixes an issue where we were accidentally displaying "The maximum length you can dredge is 1,500 metres metres".