### PR TITLE
Deal with empty address org field when saving new reg

### DIFF
--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -105,6 +105,7 @@ module FloodRiskEngine
 
     def add_address
       attributes = transferable_address_attributes(@transient_registration.company_address)
+      attributes["organisation"] ||= ""
 
       @registration.organisation.primary_address = Address.new(attributes)
     end

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -86,6 +86,16 @@ module FloodRiskEngine
         expect(enrollment.organisation.primary_address.attributes).to include(expected_address_data)
       end
 
+      context "when the address doesn't have an organisation field" do
+        before { new_registration.company_address.update(organisation: nil) }
+
+        it "assigns the correct address to the new enrollment" do
+          subject
+
+          expect(enrollment.organisation.primary_address[:organisation]).to eq("")
+        end
+      end
+
       it "assigns the correct site location to the new enrollment" do
         expect(UpdateWaterManagementAreaJob).to receive(:perform_later).with(an_instance_of(Location))
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1474

The old address DB schema requires that the "organisation" field is set. So this replicates our old fix of just filling it in with a blank if nothing else is provided.