### PR TITLE
Display missing contact position hint

### DIFF
--- a/app/views/flood_risk_engine/contact_name_forms/new.html.erb
+++ b/app/views/flood_risk_engine/contact_name_forms/new.html.erb
@@ -17,12 +17,13 @@
 
       <%= f.govuk_text_field :contact_name,
         width: 20,
-        label: { text: t(".label") },
-        hint: { text: t(".form_hint_1") }
+        label: { text: t(".contact_name.label") },
+        hint: { text: t(".contact_name.hint") }
       %>
       <%= f.govuk_text_field :contact_position,
         width: 20,
-        label: { text: t(".label1") }
+        label: { text: t(".contact_position.label") },
+        hint: { text: t(".contact_position.hint") }
       %>
 
       <%= f.govuk_submit t(".next_button") %>

--- a/config/locales/flood_risk_engine/contact_name_forms.en.yml
+++ b/config/locales/flood_risk_engine/contact_name_forms.en.yml
@@ -4,10 +4,12 @@ en:
       new:
         title: Contact name
         heading: Who should we contact about this activity?
-        label: Enter a full name
-        form_hint_1: For example, John Smith
-        label1: Enter a job title, if applicable (optional)
-        form_hint_2: For example, Project Manager
+        contact_name:
+          label: Enter a full name
+          hint: For example, John Smith
+        contact_position:
+          label: Enter a job title, if applicable (optional)
+          hint: For example, Project Manager
         legend: Who should we contact about this activity?
         para_text: We may need to contact someone to check details of the activities or arrange a site visit.
           We’ll send a confirmation of your registration to this person.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1463

This text was in the yml files but wasn't being displayed.