### PR TITLE
Fix missing address org bug for partners

### DIFF
--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -90,6 +90,7 @@ module FloodRiskEngine
 
     def build_partner_address(partner)
       attributes = transferable_address_attributes(partner.transient_address)
+      attributes["organisation"] ||= ""
 
       Address.new(attributes)
     end

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -178,6 +178,18 @@ module FloodRiskEngine
           expect(enrollment_second_partner.full_name).to eq(second_partner_name)
           expect(enrollment_second_partner.address.attributes).to include(second_partner_address_attributes)
         end
+
+        context "when the partner address doesn't have an organisation field" do
+          before { new_registration.transient_people.first.transient_address.update(organisation: nil) }
+
+          it "assigns the correct address to the new partner" do
+            subject
+
+            enrollment_first_partner = enrollment.organisation.partners.first
+
+            expect(enrollment_first_partner.address[:organisation]).to eq("")
+          end
+        end
       end
 
       context "when an error occurs" do


### PR DESCRIPTION
https://github.com/DEFRA/flood-risk-engine/pull/425

We previously fixed this bug for all other business types here: https://github.com/DEFRA/flood-risk-engine/pull/425

But that fix didn't cover partner addresses. This one does.