### PR TITLE
Don't append extra 0s to short Companies House number

### DIFF
--- a/app/forms/flood_risk_engine/company_number_form.rb
+++ b/app/forms/flood_risk_engine/company_number_form.rb
@@ -6,27 +6,8 @@ module FloodRiskEngine
 
     validates :company_number, "flood_risk_engine/company_number": true
 
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      # If param isn't set, use a blank string instead to avoid errors with the validator
-      params[:company_number] = process_company_number(params[:company_number])
-
-      super
-    end
-
     def business_type
       FloodRiskEngine::TransientRegistration::BUSINESS_TYPES.key(transient_registration.business_type)
-    end
-
-    private
-
-    def process_company_number(company_number)
-      return unless company_number.present?
-
-      number = company_number.to_s
-      # Should be 8 characters, so if it's not, add 0s to the start
-      number = "0#{number}" while number.length < 8
-      number
     end
   end
 end

--- a/spec/forms/flood_risk_engine/company_number_forms_spec.rb
+++ b/spec/forms/flood_risk_engine/company_number_forms_spec.rb
@@ -14,19 +14,6 @@ module FloodRiskEngine
         it "should submit" do
           expect(company_number_form.submit(valid_params)).to eq(true)
         end
-
-        context "when the token is less than 8 characters" do
-          before(:each) { valid_params[:company_number] = "9764739" }
-
-          it "should increase the length" do
-            company_number_form.submit(valid_params)
-            expect(company_number_form.company_number).to eq("09764739")
-          end
-
-          it "should submit" do
-            expect(company_number_form.submit(valid_params)).to eq(true)
-          end
-        end
       end
 
       context "when the form is not valid" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1462

This is something we do in WCR and WEX as the number then gets sent off to Companies House for validation. However here it just messes up the checks we do on the format, so we'd prefer to just leave the input as-is.