### PR TITLE
Fix version page in production mode

### DIFF
--- a/app/presenters/flood_risk_engine/application_version_page_presenter.rb
+++ b/app/presenters/flood_risk_engine/application_version_page_presenter.rb
@@ -6,10 +6,6 @@ module FloodRiskEngine
       FloodRiskEngine.config.application_name || Rails.application.class.module_parent_name
     end
 
-    def application_version
-      defined?(::Application::VERSION) ? Application::VERSION : "Undefined"
-    end
-
     def git_commit
       @_git_commit ||= begin
         sha =

--- a/app/presenters/flood_risk_engine/application_version_page_presenter.rb
+++ b/app/presenters/flood_risk_engine/application_version_page_presenter.rb
@@ -11,7 +11,23 @@ module FloodRiskEngine
     end
 
     def git_commit
-      @git_commit ||= GitCommitSha.current
+      @_git_commit ||= begin
+        sha =
+          if Rails.env.development?
+            `git rev-parse HEAD`
+          else
+            heroku_file = Rails.root.join ".source_version"
+            capistrano_file = Rails.root.join "REVISION"
+
+            if File.exist? capistrano_file
+              File.open(capistrano_file, &:gets)
+            elsif File.exist? heroku_file
+              File.open(heroku_file, &:gets)
+            end
+          end
+
+        sha[0...7] if sha.present?
+      end
     end
 
     def git_commit_url

--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -6,10 +6,6 @@
 
 <section>
   <p class="govuk-body">
-    <label><%= t ('.app_version') %></label>
-    <strong><%= presenter.application_version %></strong>
-  </p>
-  <p class="govuk-body">
     <label><%= t('.commit') %></label>
     <strong>
       <%= link_to(presenter.git_commit,
@@ -17,10 +13,6 @@
                   target: "_blank",
                   class: "btn-link") %>
     </strong>
-  </p>
-  <p class="govuk-body">
-    <label><%= t ('.flood_risk_engine_version') %></label>
-    <strong><%= FloodRiskEngine::VERSION %></strong>
   </p>
   <p class="govuk-body">
     <label><%= t('.render_time') %></label>

--- a/spec/presenters/flood_risk_engine/application_version_page_presenter_spec.rb
+++ b/spec/presenters/flood_risk_engine/application_version_page_presenter_spec.rb
@@ -35,9 +35,8 @@ module FloodRiskEngine
     end
 
     describe "#git_commit" do
-      it "uses GitCommitSha to derive a git hash" do
-        expect(GitCommitSha).to receive(:current).and_return("123")
-        expect(subject.git_commit).to eq("123")
+      it "returns nil when run in the test environment" do
+        expect(subject.git_commit).to eq(nil)
       end
     end
 

--- a/spec/presenters/flood_risk_engine/application_version_page_presenter_spec.rb
+++ b/spec/presenters/flood_risk_engine/application_version_page_presenter_spec.rb
@@ -23,17 +23,6 @@ module FloodRiskEngine
       end
     end
 
-    describe "#application_version" do
-      it "defaults to Undefined if an Application::VERSION is not defined" do
-        hide_const("::Application::VERSION")
-        expect(subject.application_version).to eq("Undefined")
-      end
-      it "uses the Application::VERSION if defined" do
-        stub_const("::Application::VERSION", "9.9.9")
-        expect(subject.application_version).to eq("9.9.9")
-      end
-    end
-
     describe "#git_commit" do
       it "returns nil when run in the test environment" do
         expect(subject.git_commit).to eq(nil)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1481

The old GitCommitSha method of getting the current commit worked fine in local development environments but threw an error when running in production mode. This PR cribs the fix we use in WCR and WEX to get the version from Capistrano.