### PR TITLE
Remove gem: has_secure_token

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ PATH
       defra_ruby_validators
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
-      has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
       nokogiri (>= 1.11)
       os_map_ref (= 0.4.2)
@@ -221,8 +220,6 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
-    has_secure_token (1.0.0)
-      activerecord (>= 3.0)
     hashdiff (1.0.1)
     high_voltage (3.1.2)
     htmlentities (4.3.4)

--- a/app/models/flood_risk_engine/address.rb
+++ b/app/models/flood_risk_engine/address.rb
@@ -1,5 +1,3 @@
-require_dependency "has_secure_token"
-
 module FloodRiskEngine
   class Address < ApplicationRecord
 

--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -1,5 +1,3 @@
-require_dependency "has_secure_token"
-
 module FloodRiskEngine
   class Enrollment < ApplicationRecord
     has_secure_token

--- a/app/models/flood_risk_engine/transient_registration.rb
+++ b/app/models/flood_risk_engine/transient_registration.rb
@@ -22,7 +22,7 @@ module FloodRiskEngine
     # use token instead of ID to identify an registration during the journey. The
     # format makes it sufficiently hard for another user to attempt to 'guess'
     # the token of another registration in order to see its details.
-    # See https://github.com/robertomiranda/has_secure_token
+    # See https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token
     has_secure_token
     validates_presence_of :token, on: :save
 

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -35,8 +35,6 @@ Gem::Specification.new do |s|
   # which details of the last email sent by the app can be accessed
   s.add_dependency "defra_ruby_email", "~> 1.1"
   s.add_dependency "defra_ruby_validators"
-  # Enables url obfuscation with 24bit base58 token
-  s.add_dependency "has_secure_token", "~> 1.0.0"
   # Rails engine for static pages. https://github.com/thoughtbot/high_voltage
   s.add_dependency "high_voltage", "~> 3.0"
   s.add_dependency "nokogiri", ">= 1.11"

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -1,5 +1,4 @@
 require "aasm"
-require "has_secure_token"
 require "flood_risk_engine/configuration"
 require "flood_risk_engine/exceptions"
 require "activerecord/session_store"


### PR DESCRIPTION
- This breaks in production mode w/ Rails
- Turns out we don't need it because the `has_secure_token` behaviour is now built into Rails
https://github.com/robertomiranda/has_secure_token/pull/22#issuecomment-790675958