### PR TITLE
Set assistance mode when completing registration

### DIFF
--- a/app/services/flood_risk_engine/registration_completion_service.rb
+++ b/app/services/flood_risk_engine/registration_completion_service.rb
@@ -46,7 +46,7 @@ module FloodRiskEngine
       add_exemption_location
 
       assign_reference_number
-      update_status
+      update_status_and_assistance_mode
     end
 
     def add_core_data
@@ -129,9 +129,10 @@ module FloodRiskEngine
       @registration.reference_number = ReferenceNumber.create
     end
 
-    def update_status
+    def update_status_and_assistance_mode
       @registration.enrollment_exemptions.each do |ee|
         ee.status = 1
+        ee.assistance_mode = FloodRiskEngine.config.default_assistance_mode
       end
     end
 

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -31,6 +31,7 @@ module FloodRiskEngine
     include ActiveSupport::Configurable
 
     config_accessor(:layout) { "application" }
+    config_accessor(:default_assistance_mode)
     config_accessor(:minimum_dredging_length_in_metres) { 1 }
     config_accessor(:maximum_dredging_length_in_metres) { 1500 }
     config_accessor(:git_repository_url) # Optionally used in pages/version

--- a/spec/dummy/config/initializers/flood_risk_engine.rb
+++ b/spec/dummy/config/initializers/flood_risk_engine.rb
@@ -6,6 +6,8 @@ FloodRiskEngine.configure do |config|
   config.airbrake_project_key = "abcde12345"
   config.airbrake_blocklist = [/password/i, /postcode/i]
 
+  config.default_assistance_mode = 0
+
   config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 end
 FloodRiskEngine.start_airbrake

--- a/spec/services/flood_risk_engine/registration_completion_service_spec.rb
+++ b/spec/services/flood_risk_engine/registration_completion_service_spec.rb
@@ -122,6 +122,12 @@ module FloodRiskEngine
         expect(enrollment.enrollment_exemptions.first.status).to eq("pending")
       end
 
+      it "assigns the assistance mode" do
+        subject
+
+        expect(enrollment.enrollment_exemptions.first.assistance_mode).to eq("unassisted")
+      end
+
       it "sends a confirmation email" do
         expect(SendEnrollmentSubmittedEmail).to receive(:new).with(an_instance_of(Enrollment)).and_call_original
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1604

We want to set 0 in the front office and 1 in the back office, so this makes it configurable.