### PR TITLE
Remove a partner without Javascript

### DIFF
--- a/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
+++ b/app/views/flood_risk_engine/partner_overview_forms/new.html.erb
@@ -40,7 +40,6 @@
               <%= link_to(
                     destroy_partner_overview_forms_path(partner_id: partner.id),
                     class: "link",
-                    method: :delete,
                     data: {:confirm => t(".confirm_delete", name: partner.full_name)}
                   ) do %>
                 <%= t(".remove") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,7 @@ FloodRiskEngine::Engine.routes.draw do
                     as: "back",
                     on: :collection
 
-                delete "destroy/:partner_id",
+                get "destroy/:partner_id",
                        to: "partner_overview_forms#destroy",
                        as: "destroy",
                        on: :collection
@@ -235,24 +235,6 @@ FloodRiskEngine::Engine.routes.draw do
               only: %i[new create],
               path: "registration-complete",
               path_names: { new: "" }
-  end
-
-  resources :enrollments, only: [:new, :create] do
-    resources :steps,      only: [:show, :update],  controller: "enrollments/steps"
-    resources :exemptions, only: [:destroy, :show], controller: "enrollments/exemptions"
-    resources :pages,      only: [:show],           controller: "enrollments/pages"
-
-    resources(
-      :partners, only: [:destroy, :show, :edit], controller: "enrollments/partners"
-    ) do
-      post "destroy", as: :delete, on: :member # required for deletion form on :show
-    end
-
-    resources(
-      :addresses,
-      only: [:new, :create, :edit, :update],
-      controller: "enrollments/addresses"
-    )
   end
 
   mount DefraRubyEmail::Engine => "/email"

--- a/spec/requests/flood_risk_engine/partner_overview_forms_spec.rb
+++ b/spec/requests/flood_risk_engine/partner_overview_forms_spec.rb
@@ -42,7 +42,7 @@ module FloodRiskEngine
       end
     end
 
-    describe "DELETE destroy_partner_overview_forms_path" do
+    describe "GET destroy_partner_overview_forms_path" do
       context "when a valid transient registration exists" do
         let!(:transient_registration) do
           create(:new_registration,
@@ -50,14 +50,14 @@ module FloodRiskEngine
                  workflow_state: "partner_overview_form")
         end
 
-        context "when the delete action is triggered" do
+        context "when the destroy action is triggered" do
           context "when there is only one completed partner" do
             let(:transient_people) { [build(:transient_person, :completed)] }
 
             it "destroys the partner, returns a 302 response and redirects to the partner_name form" do
               destroyable_partner_id = transient_people.first.id
-              delete destroy_partner_overview_forms_path(transient_registration[:token],
-                                                         partner_id: destroyable_partner_id)
+              get destroy_partner_overview_forms_path(transient_registration[:token],
+                                                      partner_id: destroyable_partner_id)
 
               expect { TransientPerson.find(destroyable_partner_id) }.to raise_error(ActiveRecord::RecordNotFound)
               expect(response).to have_http_status(302)
@@ -70,8 +70,8 @@ module FloodRiskEngine
 
             it "destroys the partner, returns a 302 response and redirects to the partner_overview form" do
               destroyable_partner_id = transient_people.first.id
-              delete destroy_partner_overview_forms_path(transient_registration[:token],
-                                                         partner_id: destroyable_partner_id)
+              get destroy_partner_overview_forms_path(transient_registration[:token],
+                                                      partner_id: destroyable_partner_id)
 
               expect { TransientPerson.find(destroyable_partner_id) }.to raise_error(ActiveRecord::RecordNotFound)
               expect(response).to have_http_status(302)


### PR DESCRIPTION
- Here we use a GET request to enable the Remove link on the partners page.

- This goes against RESTful conventions and isn't ideal, but it seems to work

https://eaflood.atlassian.net/browse/RUBY-1610