### PR TITLE
Add timestamps to transient records

### DIFF
--- a/db/migrate/20210621101800_create_transient_registrations.rb
+++ b/db/migrate/20210621101800_create_transient_registrations.rb
@@ -7,6 +7,8 @@ class CreateTransientRegistrations < ActiveRecord::Migration[6.0]
       t.string :workflow_state
 
       t.index :token, unique: true
+
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20210629070929_create_transient_addresses.rb
+++ b/db/migrate/20210629070929_create_transient_addresses.rb
@@ -19,6 +19,8 @@ class CreateTransientAddresses < ActiveRecord::Migration[6.0]
       t.references :addressable, polymorphic: true, index: { name: "index_addressables" }
       t.string :uprn
       t.string :token
+
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20210629071403_create_transient_people.rb
+++ b/db/migrate/20210629071403_create_transient_people.rb
@@ -6,6 +6,8 @@ class CreateTransientPeople < ActiveRecord::Migration[6.0]
       t.string :full_name
       t.string :temp_postcode
       t.belongs_to :transient_registration, index: true, foreign_key: true
+
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20210629072138_create_transient_registration_exemptions.rb
+++ b/db/migrate/20210629072138_create_transient_registration_exemptions.rb
@@ -8,6 +8,8 @@ class CreateTransientRegistrationExemptions < ActiveRecord::Migration[6.0]
       t.date :expires_on
       t.belongs_to :transient_registration, index: { name: "transient_registration_id" }
       t.belongs_to :flood_risk_engine_exemption, index: { name: "exemption_id" }
+
+      t.timestamps null: false
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -208,6 +208,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.bigint "addressable_id"
     t.string "uprn"
     t.string "token"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addressables"
   end
 
@@ -215,6 +217,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.string "full_name"
     t.string "temp_postcode"
     t.bigint "transient_registration_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["transient_registration_id"], name: "index_transient_people_on_transient_registration_id"
   end
 
@@ -224,6 +228,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.date "expires_on"
     t.bigint "transient_registration_id"
     t.bigint "flood_risk_engine_exemption_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["flood_risk_engine_exemption_id"], name: "exemption_id"
     t.index ["transient_registration_id"], name: "transient_registration_id"
   end
@@ -231,6 +237,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
   create_table "transient_registrations", force: :cascade do |t|
     t.string "token"
     t.string "workflow_state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "type", default: "FloodRiskEngine::NewRegistration", null: false
     t.string "additional_contact_email"
     t.string "business_type"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1685

While working on a ticket to remove old transient_registrations, I realised there were no timestamps on the records. So this PR amends the existing migrations to include them.

This will mean wiping and redoing the database on each environment but as we haven't rolled these out to production yet, it seemed like a cleaner way to do it than adding the timestamps as additional migrations.