### PR TITLE
Remove trailing period from `enrollment_description` helper

### DIFF
--- a/app/services/flood_risk_engine/notify/base_send_email_service.rb
+++ b/app/services/flood_risk_engine/notify/base_send_email_service.rb
@@ -19,7 +19,7 @@ module FloodRiskEngine
       end
 
       def enrollment_description
-        "#{exemption.summary} #{exemption.code}."
+        "#{exemption.summary} #{exemption.code}"
       end
     end
   end

--- a/spec/services/flood_risk_engine/notify/enrollment_submitted_email_service_spec.rb
+++ b/spec/services/flood_risk_engine/notify/enrollment_submitted_email_service_spec.rb
@@ -15,7 +15,7 @@ module FloodRiskEngine
 
         let(:exemption_description) do
           exemption = enrollment.exemptions.first
-          "#{exemption.summary} #{exemption.code}."
+          "#{exemption.summary} #{exemption.code}"
         end
 
         let(:expected_notify_options) do


### PR DESCRIPTION
- This upsets formatting of the Application Approved email