### PR TITLE
[1910] adds missing libraries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ PATH
       high_voltage (~> 3)
       jquery-rails (~> 4)
       matrix (~> 0.4)
+      net-imap (~> 0.2)
+      net-pop (~> 0.1)
       net-smtp (~> 0.3)
       nokogiri (>= 1)
       notifications-ruby-client
@@ -244,6 +246,14 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.0)
     multi_json (1.15.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -394,6 +404,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.3)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)
     thor (1.2.1)

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -52,6 +52,8 @@ Gem::Specification.new do |s|
   s.add_dependency "validates_email_format_of", "~> 1"
 
   s.add_dependency "matrix", "~> 0.4"
+  s.add_dependency "net-imap", "~> 0.2"
+  s.add_dependency "net-pop", "~> 0.1"
   s.add_dependency "net-smtp", "~> 0.3"
 
   # Pretty prints objects in console. Usage `$ ap some_object`


### PR DESCRIPTION
Deploys to dev are failing, this aims to remedy this by including gems/libraries no longer included in ruby 3.1

https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp/70500221#70500221