### PR TITLE
Error page titles

### DIFF
--- a/app/helpers/flood_risk_engine/application_helper.rb
+++ b/app/helpers/flood_risk_engine/application_helper.rb
@@ -1,9 +1,9 @@
 module FloodRiskEngine
   module ApplicationHelper
     def title
-      title_elements = [title_text, "Register a flood risk activity exemption", "GOV.UK"]
+      title_elements = [error_title, title_text, "Register a flood risk activity exemption", "GOV.UK"]
       # Remove empty elements, for example if no specific title is set
-      title_elements.delete_if(&:empty?)
+      title_elements.delete_if(&:blank?)
       title_elements.join(" - ")
     end
 
@@ -32,6 +32,10 @@ module FloodRiskEngine
 
       # Default to title for "new" action if the current action doesn't return anything
       t("#{controller_path.tr('/', '.')}.new.title", default: "")
+    end
+
+    def error_title
+      return content_for :error_title if content_for?(:error_title)
     end
   end
 end

--- a/app/views/flood_risk_engine/shared/_error_summary.html.erb
+++ b/app/views/flood_risk_engine/shared/_error_summary.html.erb
@@ -1,1 +1,3 @@
 <%= f.govuk_error_summary %>
+<% content_for :error_title, "Error" if f.govuk_error_summary %>
+

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,8 @@ module FloodRiskEngine
       context "when a specific title is provided" do
         before do
           allow(helper).to receive(:content_for?).and_return(true)
-          allow(helper).to receive(:content_for).and_return("Foo")
+          allow(helper).to receive(:content_for).with(:error_title).and_return(nil)
+          allow(helper).to receive(:content_for).with(:title).and_return("Foo")
         end
 
         it "returns the correct full title" do


### PR DESCRIPTION
This change prepends "Error" to the page title if there are form submission errors.
https://eaflood.atlassian.net/browse/RUBY-1728