### PR TITLE
RUBY-2480: moving dependency loading from engine to an app

### DIFF
--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -11,7 +11,6 @@ require "defra_ruby/validators"
 require "active_support/dependencies"
 # these classses are required on boot, so have to be loaded explicitly (since Rails 7 - zeitwerk autoloader)
 require File.expand_path("../../app/helpers/flood_risk_engine/application_helper", __dir__)
-require File.expand_path("../../app/controllers/flood_risk_engine/application_controller", __dir__)
 
 module FloodRiskEngine
   class Engine < ::Rails::Engine


### PR DESCRIPTION
moving dependency loading from engine to an app